### PR TITLE
Add Win16 PrivateProfile API support

### DIFF
--- a/fixups/FileRedirectionFixup/FileRedirectionFixup.vcxproj
+++ b/fixups/FileRedirectionFixup/FileRedirectionFixup.vcxproj
@@ -39,11 +39,14 @@
     <ClCompile Include="DeleteFileFixup.cpp" />
     <ClCompile Include="FileAttributesFixup.cpp" />
     <ClCompile Include="FindFirstFileFixup.cpp" />
+    <ClCompile Include="GetPrivateProfileSectionFixup.cpp" />
+    <ClCompile Include="GetPrivateProfileStringFixup.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="MoveFileFixup.cpp" />
     <ClCompile Include="PathRedirection.cpp" />
     <ClCompile Include="RemoveDirectoryFixup.cpp" />
     <ClCompile Include="ReplaceFileFixup.cpp" />
+    <ClCompile Include="WritePrivateProfileStringFixup.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>

--- a/fixups/FileRedirectionFixup/FunctionImplementations.h
+++ b/fixups/FileRedirectionFixup/FunctionImplementations.h
@@ -41,6 +41,8 @@ namespace impl
 
     inline auto GetFileAttributes = psf::detoured_string_function(&::GetFileAttributesA, &::GetFileAttributesW);
     inline auto GetFileAttributesEx = psf::detoured_string_function(&::GetFileAttributesExA, &::GetFileAttributesExW);
+    inline auto GetPrivateProfileString = psf::detoured_string_function(&::GetPrivateProfileStringA, &::GetPrivateProfileStringW);
+    inline auto GetPrivateProfileSection = psf::detoured_string_function(&::GetPrivateProfileSectionA, &::GetPrivateProfileSectionW);
 
     inline auto MoveFile = psf::detoured_string_function(&::MoveFileA, &::MoveFileW);
     inline auto MoveFileEx = psf::detoured_string_function(&::MoveFileExA, &::MoveFileExW);
@@ -50,6 +52,8 @@ namespace impl
     inline auto ReplaceFile = psf::detoured_string_function(&::ReplaceFileA, &::ReplaceFileW);
 
     inline auto SetFileAttributes = psf::detoured_string_function(&::SetFileAttributesA, &::SetFileAttributesW);
+
+    inline auto WritePrivateProfileString = psf::detoured_string_function(&::WritePrivateProfileStringA, &::WritePrivateProfileStringW);
 
     // Most internal use of GetFileAttributes is to check to see if a file/directory exists, so provide a helper
     template <typename CharT>

--- a/fixups/FileRedirectionFixup/GetPrivateProfileSectionFixup.cpp
+++ b/fixups/FileRedirectionFixup/GetPrivateProfileSectionFixup.cpp
@@ -1,0 +1,51 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Rafael Rivera, Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include <errno.h>
+#include "FunctionImplementations.h"
+#include "PathRedirection.h"
+
+template <typename CharT>
+DWORD __stdcall GetPrivateProfileSectionFixup(
+    _In_opt_ const CharT* appName,
+    _Out_writes_to_opt_(stringSize, return +1) CharT* string,
+    _In_ DWORD stringLength,
+    _In_opt_ const CharT* fileName) noexcept
+{
+    auto guard = g_reentrancyGuard.enter();
+    try
+    {
+        if (guard)
+        {
+            auto[shouldRedirect, redirectPath] = ShouldRedirect(fileName, redirect_flags::copy_on_read);
+            if (shouldRedirect)
+            {
+                if constexpr (psf::is_ansi<CharT>)
+                {
+                    auto wideString = std::make_unique<wchar_t[]>(stringLength);
+                    auto realRetValue = impl::GetPrivateProfileSectionW(widen_argument(appName).c_str(), wideString.get(),
+                        stringLength, redirectPath.c_str());
+
+                    if (_doserrno != ENOENT)
+                    {
+                        ::WideCharToMultiByte(CP_ACP, 0, wideString.get(), stringLength, string, stringLength, nullptr, nullptr);
+                        return realRetValue;
+                    }
+                }
+                else
+                {
+                    return impl::GetPrivateProfileSectionW(appName, string, stringLength, redirectPath.c_str());
+                }
+            }
+        }
+    }
+    catch (...)
+    {
+        // Fall back to assuming no redirection is necessary
+    }
+
+    return impl::GetPrivateProfileSection(appName, string, stringLength, fileName);
+}
+DECLARE_STRING_FIXUP(impl::GetPrivateProfileSection, GetPrivateProfileSectionFixup);

--- a/fixups/FileRedirectionFixup/GetPrivateProfileStringFixup.cpp
+++ b/fixups/FileRedirectionFixup/GetPrivateProfileStringFixup.cpp
@@ -1,0 +1,52 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Rafael Rivera, Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "FunctionImplementations.h"
+#include "PathRedirection.h"
+
+template <typename CharT>
+DWORD __stdcall GetPrivateProfileStringFixup(
+    _In_opt_ const CharT* appName,
+    _In_opt_ const CharT* keyName,
+    _In_opt_ const CharT* defaultString,
+    _Out_writes_to_opt_(returnStringSizeInChars, return +1) CharT* string,
+    _In_ DWORD stringLength,
+    _In_opt_ const CharT* fileName) noexcept
+{
+    auto guard = g_reentrancyGuard.enter();
+    try
+    {
+        if (guard)
+        {
+            auto[shouldRedirect, redirectPath] = ShouldRedirect(fileName, redirect_flags::copy_on_read);
+            if (shouldRedirect)
+            {
+                if constexpr (psf::is_ansi<CharT>)
+                {
+                    auto wideString = std::make_unique<wchar_t[]>(stringLength);
+                    auto realRetValue = impl::GetPrivateProfileStringW(widen_argument(appName).c_str(), widen_argument(keyName).c_str(),
+                        widen_argument(defaultString).c_str(), wideString.get(), stringLength, redirectPath.c_str());
+
+                    if (_doserrno != ENOENT)
+                    {
+                        ::WideCharToMultiByte(CP_ACP, 0, wideString.get(), stringLength, string, stringLength, nullptr, nullptr);
+                        return realRetValue;
+                    }
+                }
+                else
+                {
+                    return impl::GetPrivateProfileString(appName, keyName, defaultString, string, stringLength, redirectPath.c_str());
+                }
+            }
+        }
+    }
+    catch (...)
+    {
+        // Fall back to assuming no redirection is necessary
+    }
+
+    return impl::GetPrivateProfileString(appName, keyName, defaultString, string, stringLength, fileName);
+}
+DECLARE_STRING_FIXUP(impl::GetPrivateProfileString, GetPrivateProfileStringFixup);

--- a/fixups/FileRedirectionFixup/WritePrivateProfileStringFixup.cpp
+++ b/fixups/FileRedirectionFixup/WritePrivateProfileStringFixup.cpp
@@ -1,0 +1,36 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Rafael Rivera, Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "FunctionImplementations.h"
+#include "PathRedirection.h"
+
+template <typename CharT>
+BOOL __stdcall WritePrivateProfileStringFixup(
+    _In_opt_ const CharT* appName,
+    _In_opt_ const CharT* keyName,
+    _In_opt_ const CharT* string,
+    _In_opt_ const CharT* fileName) noexcept
+{
+    auto guard = g_reentrancyGuard.enter();
+    try
+    {
+        if (guard)
+        {
+            auto[shouldRedirect, redirectPath] = ShouldRedirect(fileName, redirect_flags::copy_on_read);
+            if (shouldRedirect)
+            {
+                return impl::WritePrivateProfileStringW(widen_argument(appName).c_str(), widen_argument(keyName).c_str(),
+                    widen_argument(string).c_str(), redirectPath.c_str());
+            }
+        }
+    }
+    catch (...)
+    {
+        // Fall back to assuming no redirection is necessary
+    }
+
+    return impl::WritePrivateProfileString(appName, keyName, string, fileName);
+}
+DECLARE_STRING_FIXUP(impl::WritePrivateProfileString, WritePrivateProfileStringFixup);


### PR DESCRIPTION
Adds support for Win16 APIs:
* GetPrivateProfileSection
* GetPrivateProfileString
* WritePrivateProfileString

Supports apps (like [XVI32](http://www.chmaas.handshake.de/delphi/freeware/xvi32/xvi32.htm)) attempting to write INI files to the executable install path.