### PR TITLE
Generate test certs with passwords for workgroup-only testers

### DIFF
--- a/tests/RunTests.ps1
+++ b/tests/RunTests.ps1
@@ -16,7 +16,7 @@ function RunTest($Arch, $Config)
             {
                 $appxPath = "..\Appx\$($dir.Name).appx"
                 . makeappx.exe pack /o /p "$appxPath" /f "$Arch$Config\FileMapping.txt" | Out-Null
-                . signtool.exe sign /a /v /fd sha256 /f "$pfxPath" "$appxPath" | Out-Null
+                . signtool.exe sign /a /v /fd sha256 /f "$pfxPath" /p "CentennialFixupsTestSigning" "$appxPath" | Out-Null
             }
             finally
             {

--- a/tests/scenarios/signing/CreateCert.ps1
+++ b/tests/scenarios/signing/CreateCert.ps1
@@ -102,14 +102,15 @@ function CreateCert()
         $cert = New-SelfSignedCertificate -Type Custom -Subject "$Subject" -KeyUsage DigitalSignature -FriendlyName "$FriendlyName" -CertStoreLocation "$CertStoreLocation"
     }
 
+    $Password = ConvertTo-SecureString "CentennialFixupsTestSigning" -AsPlainText -Force
     if (-not (Test-Path "$certFile"))
     {
-        Export-PfxCertificate -Cert $cert -FilePath $certFile -ProtectTo "$env:UserName" | Out-Null
+        Export-PfxCertificate -Cert $cert -FilePath $certFile -Password $Password | Out-Null
     }
 
     if ($Install)
     {
-        Import-PfxCertificate -FilePath "$certFile" -CertStoreLocation "Cert:\LocalMachine\Root"
+        Import-PfxCertificate -FilePath "$certFile" -CertStoreLocation "Cert:\LocalMachine\Root" -Password $Password
     }
 }
 


### PR DESCRIPTION
Test cert generation scripts previously used `-ProtectTo`, requiring a domain joined PC. Instead, we use a hardcoded password to support workgroup users as well.