### PR TITLE
Fix access violation with there is a single path separator at  beginning of path such as '\foo.txt'

### DIFF
--- a/fixups/FileRedirectionFixup/FindFirstFileFixup.cpp
+++ b/fixups/FileRedirectionFixup/FindFirstFileFixup.cpp
@@ -105,9 +105,19 @@ HANDLE __stdcall FindFirstFileExFixup(
     const wchar_t* pattern = nullptr;
     if (auto dirPos = path.find_last_of(LR"(\/)"); dirPos != std::wstring::npos)
     {
-        auto separator = std::exchange(path[dirPos], L'\0');
-        dir = NormalizePath(path.c_str());
-        path[dirPos] = separator;
+        // Special case for single separator at beginning of the path "/foo.txt"
+        if (dirPos == 0)
+        {
+            auto nextChar = std::exchange(path[dirPos + 1], L'\0');
+            dir = NormalizePath(path.c_str());
+            path[dirPos + 1] = nextChar;
+        }
+        else
+        {
+            auto separator = std::exchange(path[dirPos], L'\0');
+            dir = NormalizePath(path.c_str());
+            path[dirPos] = separator;
+        }
         pattern = path.c_str() + dirPos + 1;
     }
     else


### PR DESCRIPTION
This fixes rooted paths referencing single files, such as "\foo.txt" for "/bar.dll".  