### PR TITLE
Moving breakout code to closer to CreateProcess call (#129)

### DIFF
--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -3,7 +3,39 @@
 #include "Logger.h"
 #include <wil\resource.h>
 
-HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR currentDirectory, int cmdShow, DWORD timeout, LPPROC_THREAD_ATTRIBUTE_LIST attributeList = nullptr)
+
+void MakeAttributeList(LPPROC_THREAD_ATTRIBUTE_LIST &attributeList)
+{
+    SIZE_T AttributeListSize{};
+
+    InitializeProcThreadAttributeList(nullptr, 1, 0, &AttributeListSize);
+    attributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)HeapAlloc(
+        GetProcessHeap(),
+        0,
+        AttributeListSize);
+
+    THROW_LAST_ERROR_IF_MSG(
+        !InitializeProcThreadAttributeList(
+            attributeList,
+            1,
+            0,
+            &AttributeListSize),
+        "Could not initialize the proc thread attribute list.");
+
+    DWORD attribute = 0x02;
+    THROW_LAST_ERROR_IF_MSG(
+        !UpdateProcThreadAttribute(
+            attributeList,
+            0,
+            ProcThreadAttributeValue(18, FALSE, TRUE, FALSE),
+            &attribute,
+            sizeof(attribute),
+            nullptr,
+            nullptr),
+        "Could not update Proc thread attribute.");
+}
+
+HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR currentDirectory, int cmdShow, DWORD timeout)
 {
 
     STARTUPINFOEXW startupInfoEx =
@@ -26,10 +58,9 @@ HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR curren
     };
 
     PROCESS_INFORMATION processInfo{};
-    if (attributeList != nullptr)
-    {
-        startupInfoEx.lpAttributeList = attributeList;
-    }
+    LPPROC_THREAD_ATTRIBUTE_LIST attributeList;
+    MakeAttributeList(attributeList);
+    startupInfoEx.lpAttributeList = attributeList;
 
     RETURN_LAST_ERROR_IF_MSG(
         !::CreateProcessW(


### PR DESCRIPTION
* Changing sing location for Psfmonitor

* Adding output for PsfMonitor to PsfMonitor directory

* Moving PsfMonitor stuff to it's own folder

* Adding new files ot nuspec

* Changing sing location for Psfmonitor

* Adding output for PsfMonitor to PsfMonitor directory

* Moving PsfMonitor stuff to it's own folder

* Fixing issues

* Using correct WIL macro

* Moving code so atrribute list is in scopr to CreateProcess

Co-authored-by: Darren Hoehna <dahoehna@microsoft.com>