### PR TITLE
Target and Script pseudo-variables and cleaup of PR137 manual merge…

### DIFF
--- a/PsfLauncher/Logger.h
+++ b/PsfLauncher/Logger.h
@@ -15,8 +15,7 @@ void Log(const char fmt[], ...) noexcept
 
 	if (count > str.size())
 	{
-        count = 1024;       // vswprintf actually returns a negative number, let's just go with something big enough for our long strings; it is resized shortly.
-        str.resize(count);
+		str.resize(count);
 
 		va_list args2;
 		va_start(args2, fmt);

--- a/PsfLauncher/Readme.md
+++ b/PsfLauncher/Readme.md
@@ -240,21 +240,77 @@ This example shows an alternative for the json used in the prior example. This m
 }
 ```
 
+
 In this example, the pseudo-variable %MsixPackageRoot% would be replaced by the folder path that the package was installed to. This pseudo-variable is only available for string replacement by PsfLauncher in the arguments field. The example shows a reference to a file that was placed at the root of the package and another that will exist using VFS pathing. Note that as long as the LOCALAPPDATA file is the only file required from the package LOCALAPPDATA folder, the use of FileRedirectionFixup would not be mandated.
+
+### Example 4
+This example shows an alternative for the json used in the prior example. This might be used when an additional script is to be run upon first launch of the application. Such scripts are sometimes used for per-user configuration activities that must be made based on local conditions. 
+
+
+```json
+  "applications": [
+    {
+      "id": "Sample",
+      "executable": "Sample.exe",
+      "workingDirectory": "",
+      "stopOnScriptError": false,
+      "scriptExecutionMode": "-ExecutionPolicy Bypass",
+	  "startScript":
+	  {
+		"waitForScriptToFinish": true,
+		"timeout": 30000,
+		"runOnce": true,
+		"showWindow": false,
+		"scriptPath": "PackageStartScript.ps1",
+		"waitForScriptToFinish": true
+		"scriptArguments": "%MsixWritablePackageRoot%\\VFS\LocalAppData\\Vendor",
+	  },
+	  "endScript":
+	  {
+		"scriptPath": "\\server\scriptshare\\RunMeAfter.ps1",
+		"scriptArguments": "ThisIsMe.txt"
+	  }
+    }
+  ],
+  "processes": [
+    ...(taken out for brevity)
+  ]
+}
+```
+
+In this example two scripts are defined. The startScript is configured so that PsfLauncher will run this script only the first time that this user runs the application. It will wait for completion of the script before starting the executable associated with the application.  PsfLauncher will resolve the %MsixWritablePackageRoot% pseudo-variable allowing the script to write the configuration into the package redirected area (necessary since package scripts do not inject the FileRedirectionFixup).  The endScript example is configured to run after each time the application is run.
+
+Note that the scriptPath must point to a powershell ps1 file; it may be a full path reference or a reference relative to the package root folder.  In addition to this script file, the package must also include a file named "StartingScriptWrapper.ps1", which is included in the Psf sources.  This script is run by PsfLauncher for any startScript or endScript, and the wrapper will invoke the script defined in the json configuration.
+
+The use of scriptExecutionMode may only be necessary in environments when Group Policy setting of default PowerShell ExecutionPolicy is expressed. 
 
 ### Json Schema
 
 | Array | key | Value |
 |-------|-----------|-------|
 | applications | id |  Use the value of the `Id` attribute of the `Application` element in the package manifest. |
-| applications | executable | The package-relative path to the executable that you want to start. In most cases, you can get this value from your package manifest file before you modify it. It's the value of the `Executable` attribute of the `Application` element. |
-| applications | arguments | (Optional) Command line arguments for the executable.  If the PsfLauncher.exe receives any arguments, these will be appended to the command line after those from the config.json file. |
-| applications | workingDirectory | (Optional) A package-relative path to use as the working directory of the application that starts. If you don't set this value, the operating system uses the `System32` directory as the application's working directory. If you supply a value in the form of an empty string, it will use the directory of the referenced executable. |
+| applications | executable | The path to the executable that you want to start. This path is typically specified relative to the package root folder. In most cases, you can get this value from your package manifest file before you modify it. It's the value of the `Executable` attribute of the `Application` element. Pseudo-variables and Environment variables are supported for this path. |
+| applications | arguments | (Optional) Command line arguments for the executable.  If the PsfLauncher.exe receives any arguments, these will be appended to the command line after those from the config.json file. Pseudo-variables and Environment variables are supported in the arguments. |
+| applications | workingDirectory | (Optional) A path to use as the working directory of the application that starts. This is typically a relative path of the package root folder, however full paths may be specified. If you don't set this value, the operating system uses the `System32` directory as the application's working directory. If you supply a value in the form of an empty string, it will use the directory of the referenced executable. Pseudo-variables and Environment variables are supported in the workingDirectory. |
 | applications | monitor | (Optional) If present, the monitor identifies a secondary program that is to be launched prior to starting the primary application.  A good example might be `PsfMonitor.exe`.  The monitor configuration consists of the following items: |
 | | |   `'executable'` - This is the name of the executable relative to the root of the package. |
 | | |   `'arguments'`  - This is a string containing any command line arguments that the monitor executable requires. Any use of the string "%MsixPackageRoot%" in the arguments will be replaced by the a string containing the actual package root folder at runtime. |
 | | |   `'asadmin'` - This is a boolean (0 or 1) indicating if the executable needs to be launched as an admin.  To use this option set to 1, you must also mark the package with the RunAsAdministrator capability.  If the monitor executable has a manifest (internal or external) it is ignored.  If not expressed, this defaults to a 0. |
 | | |   `'wait'` - This is a boolean (0 or 1) indicating if the launcher should wait for the monitor program to exit prior to starting the primary application.  When not set, the launcher will WaitForInputIdle on the monitor before launching the primary application. This option is not normally used for tracing and defaults to 0. |
+| applications | stopOnScriptError| (Optional) Boolean. Indicates that if a startScript returns an error then the launch of the application should be skipped. |
+| applications | ScriptExecutionMode | (Optional) String value that will be added to the powershell launch of any startScript or endScript. |
+| applications | startScript | (Optional) If present, used to define a PowerShell script that will be run prior running the application executable. |
+| | |  `'waitForScriptToFinish'` - (Optional, default=false) Boolean. When true, PsfLauncher will wait for the script to complete or timeout before running the application executable. |
+| | | `'timeout'` - (Optional, default is none) Expressed in ms.  Only applicable if waitForScriptToFinish is true.  If a timeout occurs it is treated as an error for the purpose of `'stopOnScriptError'`. The value 0 means an immediate timeout, if you do not want a timeout do not specify a value. |
+| | | `'runOnce'` - (Optional, default=false) Boolean. When true, the script will only be run the first time the user runs the application. |
+| | | `'showWindow'` - (Optional, default=true). Boolean. When false, the PowerShell window is hidden. |
+| | | `'scriptPath'` - Relative or full path to a ps1 file. May be in package or on a network share. Use of pseudo-variables or environment variables are supported. |
+| | | `'scriptArguments'` - (Optional) Arguments for the `'scriptPath'` PowerShell file.  Use of pseudo-variables or environment variables are supported. |
+| applications | endScript | (Optional) If present, used to define a PowerShell script that will be run after completion of the application executable. |
+| | | `'runOnce'` - (Optional, default=false) Boolean. When true, the script will only be run the first time the user runs the application. |
+| | | `'showWindow'` - (Optional, default=true). Boolean. When false, the PowerShell window is hidden. |
+| | | `'scriptPath'` - Relative or full path to a ps1 file. May be in package or on a network share. Use of pseudo-variables or environment variables are supported. |
+| | | `'scriptArguments'` - (Optional) Arguments for the `'scriptPath'` PowerShell file.  Use of pseudo-variables or environment variables are supported. |
 | processes | executable | In most cases, this will be the name of the `executable` configured above with the path and file extension removed. |
 | fixups | dll | Package-relative path to the fixup, .msix/.appx  to load. |
 | fixups | config | (Optional) Controls how the fixup dl behaves. The exact format of this value varies on a fixup-by-fixup basis as each fixup can interpret this "blob" as it wants. |
@@ -262,6 +318,14 @@ In this example, the pseudo-variable %MsixPackageRoot% would be replaced by the 
 The `applications`, `processes`, and `fixups` keys are arrays. That means that you can use the config.json file to specify more than one application, process, and fixup DLL.
 
 An entry in `processes` has a value named `executable`, the value for which should be formed as a RegEx string to match the name of an executable process without path or file extension. The launcher will expect Windows SDK std:: library RegEx ECMAList syntax for the RegEx string.
+
+### PsfLauncher Pseudo-Variables
+The PSF Launcher supports the use of two special purpose "pseudo-variables". These pseudo-variables provide package specific locations are present on the target system.  These pseudo-variables may be used on the application executable, arguments, and workingDirectory fields, as well as in startScript/endScript scriptPath and scriptArguments.  The PSF Launcher will derefernce these variables (and any specified environment variables) prior to launching the script/application. The PSF Launcher pseudo-vairables are:
+
+| Variable| Value |
+|---------|-------|
+| %MsixPackageRoot% | The root folder of the package. While nominally this would be a subfolder under "C:\\Program Files\\WindowsApps" it is possible for the volume to be mounted in other locations. |
+| %MsixWritablePackageRoot% | The package specific redirection location for this user when the FileRedirectionFixup is in use. | 
 
 =======
 Submit your own fixup(s) to the community:

--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -35,7 +35,7 @@ void MakeAttributeList(LPPROC_THREAD_ATTRIBUTE_LIST &attributeList)
         "Could not update Proc thread attribute.");
 }
 
-HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR currentDirectory, int cmdShow, DWORD timeout)
+HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR currentDirectory, int cmdShow,  DWORD timeout)
 {
 
     STARTUPINFOEXW startupInfoEx =
@@ -85,7 +85,7 @@ HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR curren
     return ERROR_SUCCESS;
 }
 
-void StartWithShellExecute(std::filesystem::path packageRoot, std::filesystem::path exeName, std::wstring exeArgString, LPCWSTR dirStr, int cmdShow)
+void StartWithShellExecute(std::filesystem::path packageRoot, std::filesystem::path exeName, std::wstring exeArgString, LPCWSTR dirStr, int cmdShow, DWORD timeout)
 {
 	// Non Exe case, use shell launching to pick up local FTA
 	auto nonExePath = packageRoot / exeName;
@@ -107,7 +107,7 @@ void StartWithShellExecute(std::filesystem::path packageRoot, std::filesystem::p
 		"ERROR: Failed to create detoured shell process");
 
 	THROW_LAST_ERROR_IF(shex.hProcess == INVALID_HANDLE_VALUE);
-	DWORD exitCode = ::WaitForSingleObject(shex.hProcess, INFINITE);
+	DWORD exitCode = ::WaitForSingleObject(shex.hProcess, timeout);
 	THROW_IF_WIN32_ERROR(GetExitCodeProcess(shex.hProcess, &exitCode));
 	THROW_IF_WIN32_ERROR(exitCode);
 	CloseHandle(shex.hProcess);

--- a/PsfLauncher/main.cpp
+++ b/PsfLauncher/main.cpp
@@ -38,6 +38,7 @@ int launcher_main(PCWSTR args, int cmdShow) noexcept;
 void GetAndLaunchMonitor(const psf::json_object& monitor, std::filesystem::path packageRoot, int cmdShow, LPCWSTR dirStr);
 void LaunchMonitorInBackground(std::filesystem::path packageRoot, const wchar_t executable[], const wchar_t arguments[], bool wait, bool asAdmin, int cmdShow, LPCWSTR dirStr);
 bool IsCurrentOSRS2OrGreater();
+std::wstring ReplaceVariablesInString(std::wstring inputString, bool ReplaceEnvironmentVars, bool ReplacePseudoVars);
 
 static inline bool check_suffix_if(iwstring_view str, iwstring_view suffix) noexcept;
 
@@ -56,17 +57,26 @@ int launcher_main(PCWSTR args, int cmdShow) noexcept try
 
     auto dirPtr = appConfig->try_get("workingDirectory");
     auto dirStr = dirPtr ? dirPtr->as_string().wide() : L"";
-    auto exeArgs = appConfig->try_get("arguments");
 
     // At least for now, configured launch paths are relative to the package root
     std::filesystem::path packageRoot = PSFQueryPackageRootPath();
-    auto currentDirectory = (packageRoot / dirStr);
+    std::wstring dirWstr = dirStr;
+    dirWstr = ReplaceVariablesInString(dirWstr, true, true);
+    std::filesystem::path currentDirectory;
+    if (dirWstr[1] != L':')
+    {
+        currentDirectory = (packageRoot / dirWstr);
+    }
+    else
+    {
+        currentDirectory = dirWstr;
+    }
 
     PsfPowershellScriptRunner powershellScriptRunner;
 
     if (IsCurrentOSRS2OrGreater())
     {
-        powershellScriptRunner.Initialize(appConfig, currentDirectory);
+        powershellScriptRunner.Initialize(appConfig, currentDirectory, packageRoot);
 
         // Launch the starting PowerShell script if we are using one.
         powershellScriptRunner.RunStartingScript();
@@ -82,31 +92,40 @@ int launcher_main(PCWSTR args, int cmdShow) noexcept try
 
     // Launch underlying application.
     auto exeName = appConfig->get("executable").as_string().wide();
-    auto exePath = packageRoot / exeName;
-    std::wstring exeArgString = exeArgs ? exeArgs->as_string().wide() : (wchar_t*)L"";
-
-    //Allow for a substitution in the arguments for a new pseudo variable %MsixPackageRoot% so that arguments can point to files
-    //inside the package using a syntax relative to the package root rather than rely on VFS pathing which can't kick in yet.
-    std::wstring::size_type pos = 0u;
-    std::wstring var2rep = L"%MsixPackageRoot%";
-    std::wstring repargs = packageRoot.c_str();
-    while ((pos = exeArgString.find(var2rep, pos)) != std::string::npos) {
-        exeArgString.replace(pos, var2rep.length(), repargs);
-        pos += repargs.length();
+    std::wstring exeWName = exeName;
+    exeWName = ReplaceVariablesInString(exeWName, true, true);
+    std::filesystem::path exePath;
+    if (exeWName[1] != L':')
+    {
+        exePath = packageRoot / exeWName;
     }
+    else
+    {
+        exePath = exeWName;
+    }
+    
+    auto exeArgs = appConfig->try_get("arguments"); 
+    std::wstring exeArgString = exeArgs ? exeArgs->as_string().wide() : (wchar_t*)L"";
+    exeArgString = ReplaceVariablesInString(exeArgString, true, true);
 
     // Keep these quotes here.  StartProcess assumes there are quotes around the exe file name
     if (check_suffix_if(exeName, L".exe"_isv))
     {
-        std::wstring fullargs = (L"\"" + exePath.filename().native() + L"\" " + exeArgString + L" " + args);
+        std::wstring fullargs = (L"\"" + exePath.native() + L"\" " + exeArgString + L" " + args);
         LogString("Process Launch: ", fullargs.data());
-        StartProcess(exePath.c_str(), fullargs.data(), (packageRoot / dirStr).c_str(), cmdShow, INFINITE);
+        LogString("Working Directory: ", currentDirectory.c_str());
+        HRESULT hr = StartProcess(exePath.c_str(), fullargs.data(), currentDirectory.c_str(), cmdShow,  INFINITE);
+        if (hr != ERROR_SUCCESS)
+        {
+            Log("Error return from launching process.");
+        }
     }
     else
     {
-        LogString("Shell Launch", exeName);
+        LogString("Shell Launch", exePath.c_str());
         LogString("   Arguments", exeArgString.c_str());
-        StartWithShellExecute(packageRoot, exeName, exeArgString.c_str(), dirStr, cmdShow);
+        LogString("Working Directory: ", currentDirectory.c_str());
+        StartWithShellExecute(packageRoot, exePath, exeArgString, currentDirectory.c_str(), cmdShow, INFINITE);
     }
 
     if (IsCurrentOSRS2OrGreater())
@@ -194,6 +213,44 @@ void LaunchMonitorInBackground(std::filesystem::path packageRoot, const wchar_t 
     }
 }
 
+
+// Replace all occurrences of requested environment and/or pseudo-environment variables in a string.
+std::wstring ReplaceVariablesInString(std::wstring inputString, bool ReplaceEnvironmentVars, bool ReplacePseudoVars)
+{
+    std::wstring outputString = inputString;
+    if (ReplacePseudoVars)
+    {
+        std::wstring::size_type pos = 0u;
+        std::wstring var2rep = L"%MsixPackageRoot%";
+        std::wstring repargs = PSFQueryPackageRootPath();
+        while ((pos = outputString.find(var2rep, pos)) != std::string::npos) {
+            outputString.replace(pos, var2rep.length(), repargs);
+            pos += repargs.length();
+        }
+
+        pos = 0u;
+        var2rep = L"%MsixWritablePackageRoot%";
+        std::filesystem::path writablePackageRootPath = psf::known_folder(FOLDERID_LocalAppData) / std::filesystem::path(L"Packages") / psf::current_package_family_name() / LR"(LocalCache\Local\Microsoft\WritablePackageRoot)";
+        repargs = writablePackageRootPath.c_str();
+        while ((pos = outputString.find(var2rep, pos)) != std::string::npos) {
+            outputString.replace(pos, var2rep.length(), repargs);
+            pos += repargs.length();
+        }
+    }
+    if (ReplaceEnvironmentVars)
+    {
+        // Potentially an environment variable that needs replacing. For Example: "%HomeDir%\\Documents"
+        DWORD nSizeBuff = 256;
+        LPWSTR buff = new wchar_t[nSizeBuff];
+        DWORD nSizeRet = ExpandEnvironmentStrings(outputString.c_str(), buff, nSizeBuff);
+        if (nSizeRet > 0)
+        {
+            outputString = std::wstring(buff);
+        }
+
+    }
+    return outputString;
+}
 
 
 static inline bool check_suffix_if(iwstring_view str, iwstring_view suffix) noexcept


### PR DESCRIPTION
…issues.

This PR makes the 2 pseudo-variables added in PR#137 useable for both scripting and primary app target executable in PsfLauncher.  This solves issues with certain existing WIn32 application shortcuts that could not be handled without the variablization in command line arguments for full path location references within the package. Improved logging in the launching and scripting steps to aid in debugging are also included. 

Finally, this PR cleans up some issues that arose from PR#137 due to manual merging.