### PR TITLE
Don't throw error to user when shell launch returns non-zero, just lo…

### DIFF
--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -76,8 +76,10 @@ void StartWithShellExecute(std::filesystem::path packageRoot, std::filesystem::p
 
 	THROW_LAST_ERROR_IF(shex.hProcess == INVALID_HANDLE_VALUE);
 	DWORD exitCode = ::WaitForSingleObject(shex.hProcess, timeout);
-	THROW_IF_WIN32_ERROR(GetExitCodeProcess(shex.hProcess, &exitCode));
-	THROW_IF_WIN32_ERROR(exitCode);
+
+    // Don't throw an error as we should assume that the process would have appropriately made indications to the user.  Log for debug purposes only.
+    Log("PsfLauncher: Shell Launch: process returned exit code 0x%x", exitCode);
+
 	CloseHandle(shex.hProcess);
 }
 


### PR DESCRIPTION
Make a change to PsfLauncher when processing a shell launch.  Previously, if the launched file process returned with a non-zero return, an error dialog would be thrown to the user.

Not all non-zero returns are errors, and even if they are we should assume that the process already notified the user if relevant. Code not logs the error for debugging purposes instead.

This PR will resolve this issue: https://github.com/microsoft/MSIX-PackageSupportFramework/issues/156 