### PR TITLE
Issues 95, 141, 152, 159, 168, and 169, and 171

### DIFF
--- a/PsfLauncher/PsfPowershellScriptRunner.h
+++ b/PsfLauncher/PsfPowershellScriptRunner.h
@@ -443,7 +443,16 @@ private:
 		}
 		else if (createResult != ERROR_SUCCESS)
 		{
-			THROW_HR_MSG(HRESULT_FROM_WIN32(createResult), "Error with getting the key to see if PowerShell is installed.");
+			// Certain systems lack the 1 key but have the 3 key (both point to same path)
+			createResult = RegCreateKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\PowerShell\\3", 0, nullptr, REG_OPTION_NON_VOLATILE, KEY_READ, nullptr, &registryHandle, nullptr);
+			if (createResult == ERROR_FILE_NOT_FOUND)
+			{
+				return false;
+			}
+			else if (createResult != ERROR_SUCCESS)
+			{
+				THROW_HR_MSG(HRESULT_FROM_WIN32(createResult), "Error with getting the key to see if PowerShell is installed.");
+			}
 		}
 
 		DWORD valueFromRegistry = 0;

--- a/PsfLauncher/Readme.md
+++ b/PsfLauncher/Readme.md
@@ -248,7 +248,7 @@ In this example, the pseudo-variable %MsixPackageRoot% would be replaced by the 
 ### Example 4
 This example shows an alternative for the json used in the prior example. This might be used when an additional script is to be run upon first launch of the application. Such scripts are sometimes used for per-user configuration activities that must be made based on local conditions.
 
-To implement scripting PsfLauncher uses a PowerShell script as an intermediator.  PshLauncher will expect to find a file StartingScriptWrapper.ps1, which is included as part of the PSD, to call the PowerShell script that is referenced in the Json.  The wrapper script should be placed in the package as the same folder used by the launcher.
+To implement scripting PsfLauncher uses a PowerShell script as an intermediator.  PshLauncher will expect to find a file StartingScriptWrapper.ps1, which is included as part of the PSF, to call the PowerShell script that is referenced in the Json.  The wrapper script should be placed in the package as the same folder used by the launcher.
 
 
 ```json

--- a/PsfLauncher/Readme.md
+++ b/PsfLauncher/Readme.md
@@ -6,6 +6,8 @@ Based on the manifest's application ID, the `psfLauncher` looks for the app's la
 
 PSF Launcher also supports running an additional "monitor" app, intended for PsfMonitor. You use PsfMonitor to view the output in conjuction with TraceFixup injection configured to output to events.
 
+Finally, PsfLauncher also support some limited PowerShell scripting.
+
 ## Configuration
 PSF Launcher uses a config.json file to configure the behavior.
 
@@ -244,7 +246,9 @@ This example shows an alternative for the json used in the prior example. This m
 In this example, the pseudo-variable %MsixPackageRoot% would be replaced by the folder path that the package was installed to. This pseudo-variable is only available for string replacement by PsfLauncher in the arguments field. The example shows a reference to a file that was placed at the root of the package and another that will exist using VFS pathing. Note that as long as the LOCALAPPDATA file is the only file required from the package LOCALAPPDATA folder, the use of FileRedirectionFixup would not be mandated.
 
 ### Example 4
-This example shows an alternative for the json used in the prior example. This might be used when an additional script is to be run upon first launch of the application. Such scripts are sometimes used for per-user configuration activities that must be made based on local conditions. 
+This example shows an alternative for the json used in the prior example. This might be used when an additional script is to be run upon first launch of the application. Such scripts are sometimes used for per-user configuration activities that must be made based on local conditions.
+
+To implement scripting PsfLauncher uses a PowerShell script as an intermediator.  PshLauncher will expect to find a file StartingScriptWrapper.ps1, which is included as part of the PSD, to call the PowerShell script that is referenced in the Json.  The wrapper script should be placed in the package as the same folder used by the launcher.
 
 
 ```json

--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -29,6 +29,9 @@ HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR curren
     PROCESS_INFORMATION processInfo{};
 
     startupInfoEx.lpAttributeList = attributeList;
+    DWORD CreationFlags = 0;
+    if (attributeList != NULL)
+        CreationFlags = EXTENDED_STARTUPINFO_PRESENT;
 
     RETURN_LAST_ERROR_IF_MSG(
         !::CreateProcessW(
@@ -36,7 +39,7 @@ HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR curren
             commandLine,
             nullptr, nullptr, // Process/ThreadAttributes
             true, // InheritHandles
-            EXTENDED_STARTUPINFO_PRESENT, // CreationFlags
+            CreationFlags,
             nullptr, // Environment
             currentDirectory,
             (LPSTARTUPINFO)&startupInfoEx,

--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -31,8 +31,10 @@ HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR curren
     startupInfoEx.lpAttributeList = attributeList;
     DWORD CreationFlags = 0;
     if (attributeList != NULL)
+    {
         CreationFlags = EXTENDED_STARTUPINFO_PRESENT;
-
+    }
+    
     RETURN_LAST_ERROR_IF_MSG(
         !::CreateProcessW(
             applicationName,

--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -76,8 +76,10 @@ void StartWithShellExecute(std::filesystem::path packageRoot, std::filesystem::p
 
 	THROW_LAST_ERROR_IF(shex.hProcess == INVALID_HANDLE_VALUE);
 	DWORD exitCode = ::WaitForSingleObject(shex.hProcess, timeout);
-	THROW_IF_WIN32_ERROR(GetExitCodeProcess(shex.hProcess, &exitCode));
-	THROW_IF_WIN32_ERROR(exitCode);
+
+    // Don't throw an error as we should assume that the process would have appropriately made indications to the user.  Log for debug purposes only.
+    Log("PsfLauncher: Shell Launch: process returned exit code 0x%x", exitCode);
+
 	CloseHandle(shex.hProcess);
 }
 

--- a/PsfLauncher/main.cpp
+++ b/PsfLauncher/main.cpp
@@ -60,7 +60,7 @@ int launcher_main(PCWSTR args, int cmdShow) noexcept try
 #ifdef _DEBUG 
     if (appConfig) 
     { 
-        auto waitSignalPtr = appConfig->try_get("WaitForDebugger"); 
+        auto waitSignalPtr = appConfig->try_get("waitForDebugger"); 
         if (waitSignalPtr) 
         { 
             bool waitSignal = waitSignalPtr->as_boolean().get(); 

--- a/fixups/DynamicLibraryFixup/DynamicLibraryFixup.cpp
+++ b/fixups/DynamicLibraryFixup/DynamicLibraryFixup.cpp
@@ -28,7 +28,7 @@ HMODULE __stdcall LoadLibraryFixup(_In_ const CharT* libFileName)
         Log("LoadLibraryFixup unguarded.");
 #endif
         // Check against known dlls in package.
-        std::wstring libFileNameW = InterpretStringW(libFileName);
+        std::wstring libFileNameW = GetFilenameOnly(InterpretStringW(libFileName));
 
         if (g_dynf_forcepackagedlluse)
         {

--- a/fixups/DynamicLibraryFixup/FunctionImplementations.h
+++ b/fixups/DynamicLibraryFixup/FunctionImplementations.h
@@ -31,6 +31,13 @@ inline std::wstring InterpretStringW(const wchar_t* value)
     return value;
 }
 
+inline std::wstring GetFilenameOnly(std::wstring path)
+{
+    size_t index = path.find_last_of(L"\\", std::wstring::npos);
+    if (index == std::wstring::npos)
+        return path;
+    return path.substr(index + 1);
+}
 
 void Log(const char* fmt, ...);
 void LogString(const char* name, const char* value);

--- a/fixups/FileRedirectionFixup/FileRedirectionFixup.vcxproj
+++ b/fixups/FileRedirectionFixup/FileRedirectionFixup.vcxproj
@@ -49,6 +49,7 @@
     <ClCompile Include="PathRedirection.cpp" />
     <ClCompile Include="RemoveDirectoryFixup.cpp" />
     <ClCompile Include="ReplaceFileFixup.cpp" />
+    <ClCompile Include="SetWorkingDirectory.cpp" />
     <ClCompile Include="WritePrivateProfileSectionFixup.cpp" />
     <ClCompile Include="WritePrivateProfileStringFixup.cpp" />
     <ClCompile Include="WritePrivateProfileStructFixup.cpp" />

--- a/fixups/FileRedirectionFixup/FunctionImplementations.h
+++ b/fixups/FileRedirectionFixup/FunctionImplementations.h
@@ -56,6 +56,8 @@ namespace impl
 
     inline auto SetFileAttributes = psf::detoured_string_function(&::SetFileAttributesA, &::SetFileAttributesW);
 
+    inline auto SetCurrentDirectory = psf::detoured_string_function(&::SetCurrentDirectoryA, &::SetCurrentDirectoryW);
+
     inline auto WritePrivateProfileSection = psf::detoured_string_function(&::WritePrivateProfileSectionA, &::WritePrivateProfileSectionW);
     inline auto WritePrivateProfileString = psf::detoured_string_function(&::WritePrivateProfileStringA, &::WritePrivateProfileStringW);
     inline auto WritePrivateProfileStruct = psf::detoured_string_function(&::WritePrivateProfileStructA, &::WritePrivateProfileStructW);

--- a/fixups/FileRedirectionFixup/PathRedirection.cpp
+++ b/fixups/FileRedirectionFixup/PathRedirection.cpp
@@ -1201,6 +1201,12 @@ static path_redirect_info ShouldRedirectImpl(const CharT* path, redirect_flags f
     }
     LogString(inst, L"\tFRF Should: for path", widen(path).c_str());
     
+    size_t found = (widen(path)).find(L"WritablePackageRoot", 0);
+    if (found != 0)
+    {
+        LogString(inst, L"Prevent inception", widen(path).c_str());
+        return result;
+    }
 
     bool c_presense = flag_set(flags, redirect_flags::check_file_presence);
     bool c_copy = flag_set(flags, redirect_flags::copy_file);

--- a/fixups/FileRedirectionFixup/PathRedirection.cpp
+++ b/fixups/FileRedirectionFixup/PathRedirection.cpp
@@ -1204,7 +1204,7 @@ static path_redirect_info ShouldRedirectImpl(const CharT* path, redirect_flags f
     size_t found = (widen(path)).find(L"WritablePackageRoot", 0);
     if (found != 0)
     {
-        LogString(inst, L"Prevent inception", widen(path).c_str());
+        LogString(inst, L"Prevent redundant redirection.", widen(path).c_str());
         return result;
     }
 

--- a/fixups/FileRedirectionFixup/SetWorkingDirectory.cpp
+++ b/fixups/FileRedirectionFixup/SetWorkingDirectory.cpp
@@ -1,0 +1,46 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) TMurgent Technologies, LLP. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "FunctionImplementations.h"
+#include "PathRedirection.h"
+
+
+template <typename CharT>
+BOOL __stdcall SetCurrentDirectoryFixup(_In_ const CharT* filePath) noexcept
+{
+    auto guard = g_reentrancyGuard.enter();
+    try
+    {
+        if (guard)
+        {
+            DWORD SetWorkingDirectoryInstance = ++g_FileIntceptInstance;
+            LogString(SetWorkingDirectoryInstance, L"SetCurrentDirectoryFixup ", filePath);
+            if (!path_relative_to(filePath, psf::current_package_path()))
+            {
+                normalized_path normalized = NormalizePath(filePath);
+                normalized_path virtualized = VirtualizePath(normalized, SetWorkingDirectoryInstance);
+                if (impl::PathExists(virtualized.full_path.c_str()))
+                {
+                    return impl::SetCurrentDirectory(virtualized.full_path.c_str());
+                }
+                else
+                {
+                    // Fall through to original call
+                }
+            }
+            else
+            {
+                // Fall through to original call
+            }
+        }
+    }
+    catch (...)
+    {
+        // Fall back to assuming no redirection is necessary
+    }
+
+    return impl::SetCurrentDirectory(filePath);
+}
+DECLARE_STRING_FIXUP(impl::SetCurrentDirectory, SetCurrentDirectoryFixup);


### PR DESCRIPTION
Fixes for documented issues:
**Issue 95** -  Update to documentatin on PsfLauncher to mention the requirement for StartingScriptWrapper.ps1 file.
**Issue 141** - Don't set CreationFlags when starting a process if the attributesList wasn't supplied.
**Issue 152** - Find PowerShell.exe when system doesn't have the '1' registry key.
**Issue 159** - Add intercept for SetWorkingDirectory
**Issue 168** - let DynamicLibraryFixup support dll loading with full path inputs.
**Issue 169** - Stop FRF inception (don't redirect again if passed WritablePackageRoot).
**Issue 171** - PsfLauncher reading incorrect case for waitForDebugger.