### PR TITLE
Fix for redundancy check in ShouldRedirect

### DIFF
--- a/fixups/FileRedirectionFixup/PathRedirection.cpp
+++ b/fixups/FileRedirectionFixup/PathRedirection.cpp
@@ -1202,7 +1202,7 @@ static path_redirect_info ShouldRedirectImpl(const CharT* path, redirect_flags f
     LogString(inst, L"\tFRF Should: for path", widen(path).c_str());
     
     size_t found = (widen(path)).find(L"WritablePackageRoot", 0);
-    if (found != 0)
+    if (found != std::wstring::npos)
     {
         LogString(inst, L"Prevent redundant redirection.", widen(path).c_str());
         return result;


### PR DESCRIPTION
This is to fix issue #174 

This replaces the previous PR that brought in too many files.