### PR TITLE
Fix for issue #179 Not finding StartingScriptWrapper.ps1

### DIFF
--- a/PsfLauncher/PsfPowershellScriptRunner.h
+++ b/PsfLauncher/PsfPowershellScriptRunner.h
@@ -291,7 +291,7 @@ private:
 
 	std::wstring MakeCommandString(const psf::json_object& scriptInformation, const std::wstring& scriptExecutionMode, const std::wstring& scriptPath)
 	{
-		std::wstring commandString = L"Powershell.exe ";
+		std::wstring commandString = L"Powershell.exe "; 
 		commandString.append(scriptExecutionMode);
 		commandString.append(L" -file StartingScriptWrapper.ps1 ");
 		commandString.append(L"\"");


### PR DESCRIPTION
Ensure that if StartingScriptWrapper.ps1 is not in the working directory that it is found as long as it is somewhere inside the package.