### PR TITLE
Added the test ini file in the redirection pattern to fix failing test

### DIFF
--- a/tests/scenarios/FileSystemTest/config.json
+++ b/tests/scenarios/FileSystemTest/config.json
@@ -22,6 +22,7 @@
                   "base": "",
                   "patterns": [
                     ".*\\.txt",
+                    "TestIniFile.ini",
                     "Tèƨƭ.*"
                   ]
                 }

--- a/tests/scenarios/FileSystemTest/config.json
+++ b/tests/scenarios/FileSystemTest/config.json
@@ -22,7 +22,7 @@
                   "base": "",
                   "patterns": [
                     ".*\\.txt",
-                    "TestIniFile.ini",
+                    ".*\\.ini",
                     "Tèƨƭ.*"
                   ]
                 }


### PR DESCRIPTION
Private profile tests were failing because the file used in the test for updating the string was not being identified from the redirection pattern.

> Added the file name in the pattern