### PR TITLE
Fix for power shell script with arguments

### DIFF
--- a/PsfLauncher/PsfPowershellScriptRunner.h
+++ b/PsfLauncher/PsfPowershellScriptRunner.h
@@ -319,16 +319,16 @@ private:
 		std::wstring fixed4PowerShell = dequotedScriptPath; // EscapeFilenameForPowerShell(dequotedScriptPath);
 		if (dequotedScriptPath.is_absolute())
 		{
-			commandString.append(L"\"");
+			commandString.append(L"\'");
 			commandString.append(fixed4PowerShell);
-			commandString.append(L"\"");
+			commandString.append(L"\'");
 		}
 		else
 		{
-			commandString.append(L"\"");
+			commandString.append(L"\'");
 			commandString.append(L".\\");
 			commandString.append(fixed4PowerShell);
-			commandString.append(L"\"");
+			commandString.append(L"\'");
 		}
 
 		//Script arguments are optional.


### PR DESCRIPTION
Current format used to run Powershell script with arguments is invalid. This has been corrected.

Command that will be used to run powershell script is Powershell.exe -file "[wrapperScript PS1]>" "Powershell.exe -file '[User script PS1]' '[Arg1]' '[Arg2]' "