### PR TITLE
PSFMontor folder restructuring in Release folder 

### DIFF
--- a/Microsoft.PackageSupportFramework.nuspec
+++ b/Microsoft.PackageSupportFramework.nuspec
@@ -41,12 +41,11 @@
     <file src="x64\Release\Microsoft.Diagnostics.FastSerialization.dll" target="bin\PsfMonitor\x64"/>
     <file src="x64\Release\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="bin\PsfMonitor\x64"/>
     <file src="x64\Release\OsExtensions.dll" target="bin\PsfMonitor\x64"/>
-    <file src="Win32\Release\PsfMonitor*.exe" target="bin\PsfMonitor\Win32"/>
-    <file src="Win32\Release\x86\*" target="bin\PsfMonitor\Win32\x86"/>
-    <file src="Win32\Release\amd64\*" target="bin\PsfMonitor\Win32\amd64"/>
-    <file src="Win32\Release\Dia2Lib.dll" target="bin\PsfMonitor\Win32"/>
-    <file src="Win32\Release\Microsoft.Diagnostics.FastSerialization.dll" target="bin\PsfMonitor\Win32"/>
-    <file src="Win32\Release\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="bin\PsfMonitor\Win32"/>
-    <file src="Win32\Release\OsExtensions.dll" target="bin\PsfMonitor\Win32"/>  
+	<file src="Win32\Release\PsfMonitor*.exe" target="bin\PsfMonitor\x86"/>
+	<file src="Win32\Release\x86\*" target="bin\PsfMonitor\x86\x86"/>
+	<file src="Win32\Release\Dia2Lib.dll" target="bin\PsfMonitor\x86"/>
+	<file src="Win32\Release\Microsoft.Diagnostics.FastSerialization.dll" target="bin\PsfMonitor\x86"/>
+	<file src="Win32\Release\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="bin\PsfMonitor\x86"/>
+	<file src="Win32\Release\OsExtensions.dll" target="bin\PsfMonitor\x86"/>
   </files>
 </package>

--- a/Microsoft.PackageSupportFramework.nuspec
+++ b/Microsoft.PackageSupportFramework.nuspec
@@ -41,11 +41,11 @@
     <file src="x64\Release\Microsoft.Diagnostics.FastSerialization.dll" target="bin\PsfMonitor\x64"/>
     <file src="x64\Release\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="bin\PsfMonitor\x64"/>
     <file src="x64\Release\OsExtensions.dll" target="bin\PsfMonitor\x64"/>
-	<file src="Win32\Release\PsfMonitor*.exe" target="bin\PsfMonitor\x86"/>
-	<file src="Win32\Release\x86\*" target="bin\PsfMonitor\x86\x86"/>
-	<file src="Win32\Release\Dia2Lib.dll" target="bin\PsfMonitor\x86"/>
-	<file src="Win32\Release\Microsoft.Diagnostics.FastSerialization.dll" target="bin\PsfMonitor\x86"/>
-	<file src="Win32\Release\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="bin\PsfMonitor\x86"/>
-	<file src="Win32\Release\OsExtensions.dll" target="bin\PsfMonitor\x86"/>
+    <file src="Win32\Release\PsfMonitor*.exe" target="bin\PsfMonitor\x86"/>
+    <file src="Win32\Release\x86\*" target="bin\PsfMonitor\x86\x86"/>
+    <file src="Win32\Release\Dia2Lib.dll" target="bin\PsfMonitor\x86"/>
+    <file src="Win32\Release\Microsoft.Diagnostics.FastSerialization.dll" target="bin\PsfMonitor\x86"/>
+    <file src="Win32\Release\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="bin\PsfMonitor\x86"/>
+    <file src="Win32\Release\OsExtensions.dll" target="bin\PsfMonitor\x86"/>
   </files>
 </package>


### PR DESCRIPTION
-Include x86 DLLs alone in psfMonitor x86 folder
-Use x86 folder name instead of Win32 in psfMonitor