### PR TITLE
CreateProcess Argument redirection feature (#220)

### DIFF
--- a/PsfRuntime/ArgRedirection.h
+++ b/PsfRuntime/ArgRedirection.h
@@ -1,0 +1,110 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#include <known_folders.h>
+
+constexpr int MAX_CMDLINE_PATH = 32767;
+auto GetFileAttributesImpl = psf::detoured_string_function(&::GetFileAttributesA, &::GetFileAttributesW);
+
+template <typename CharT>
+bool IsUnderUserAppDataAndReplace(const CharT* fileName, CharT* cmdLine, bool AppDataLocal)
+{
+    bool isUnderAppData = false;
+    bool result = false;
+
+    if (!fileName)
+    {
+        return result;
+    }
+    constexpr wchar_t root_local_device_prefix[] = LR"(\\?\)";
+    constexpr wchar_t root_local_device_prefix_dot[] = LR"(\\.\)";
+
+    GUID appDataFolderId = AppDataLocal ? FOLDERID_LocalAppData : FOLDERID_RoamingAppData;
+
+    if (std::equal(root_local_device_prefix, root_local_device_prefix + wcslen(root_local_device_prefix), fileName))
+    {
+        isUnderAppData = is_path_relative(fileName + wcslen(root_local_device_prefix), psf::known_folder(appDataFolderId));
+    }
+    else if (std::equal(root_local_device_prefix_dot, root_local_device_prefix_dot + wcslen(root_local_device_prefix_dot), fileName))
+    {
+        isUnderAppData = is_path_relative(fileName + wcslen(root_local_device_prefix_dot), psf::known_folder(appDataFolderId));
+    }
+    else
+    {
+        isUnderAppData = is_path_relative(fileName, psf::known_folder(appDataFolderId));
+    }
+
+    size_t remBufSize = MAX_CMDLINE_PATH - strlenImpl(cmdLine);
+    if (isUnderAppData)
+    {
+        std::filesystem::path strLocalRoaming = AppDataLocal ? std::filesystem::path(L"Local") : std::filesystem::path(L"Roaming");
+        std::filesystem::path appDataPath = psf::known_folder(appDataFolderId);
+        auto packageAppDataPath = psf::known_folder(FOLDERID_LocalAppData) / std::filesystem::path(L"Packages") / psf::current_package_family_name() / LR"(LocalCache)" / strLocalRoaming;
+        std::wstring relativePath = widen(fileName + (appDataPath.native().length()));
+        std::wstring fullPath = packageAppDataPath.native() + relativePath;
+
+        if (GetFileAttributesImpl(fullPath.c_str()) != INVALID_FILE_ATTRIBUTES)
+        {
+            result = true;
+            if (std::is_same<CharT, char>::value)
+            {
+                size_t fullPathLen = fullPath.length();
+                size_t bytes_written;
+                std::unique_ptr<char[]> fullPath_char(new char[fullPathLen + 1]);
+                wcstombs_s(&bytes_written, fullPath_char.get(), fullPathLen + 1, fullPath.c_str(), fullPathLen);
+                strcatImpl(cmdLine, remBufSize, (const CharT*)(fullPath_char.get()));
+            }
+            else
+            {
+                strcatImpl(cmdLine, remBufSize, (CharT*)(fullPath.c_str()));
+            }
+        }
+    }
+    return result;
+}
+
+// checks each space separated command line parameter and changes from native local app data folder to per user per app data folder if the file referred in command line parameter is present in per user per app data folder, else it remains the same
+template <typename CharT>
+void convertCmdLineParameters(CharT* inputCmdLine, CharT* cnvtCmdLine)
+{
+    CharT* next_token;
+    size_t cmdLinelen = strlenImpl(inputCmdLine);
+    std::unique_ptr<CharT[]> cmdLine(new CharT[cmdLinelen+1]);
+    if (cmdLine.get())
+    {
+        memset(cmdLine.get(), 0, cmdLinelen+1);
+        strcatImpl(cmdLine.get(), cmdLinelen+1, inputCmdLine);
+    }
+    else
+    {
+        strcatImpl(cnvtCmdLine, MAX_CMDLINE_PATH, inputCmdLine);
+        return;
+    }
+
+    CharT* token = strtokImpl(cmdLine.get(), (CharT*)L" ", &next_token);
+    bool redirectResult = false;
+    size_t remBufSize; 
+
+    while (token != nullptr)
+    {
+        redirectResult = IsUnderUserAppDataAndReplace(token, cnvtCmdLine, true);
+        if (redirectResult == false)
+        {
+            redirectResult = IsUnderUserAppDataAndReplace(token, cnvtCmdLine, false);
+        }
+
+        if (!redirectResult)
+        {
+            remBufSize = MAX_CMDLINE_PATH - strlenImpl(cnvtCmdLine);
+            strcatImpl(cnvtCmdLine, remBufSize, token);
+        }
+        token = strtokImpl((CharT*)nullptr, (CharT*)L" ", &next_token);
+        if (token != nullptr)
+        {
+            remBufSize = MAX_CMDLINE_PATH - strlenImpl(cnvtCmdLine);
+            strcatImpl(cnvtCmdLine, remBufSize, (CharT*)L" ");
+        }
+    }
+    return;
+}

--- a/PsfRuntime/PsfRuntime.vcxproj
+++ b/PsfRuntime/PsfRuntime.vcxproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ClInclude Include="Config.h" />
     <ClInclude Include="JsonConfig.h" />
+    <ClInclude Include="ArgRedirection.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Detours\Detours.vcxproj">

--- a/PsfRuntime/PsfRuntime.vcxproj.filters
+++ b/PsfRuntime/PsfRuntime.vcxproj.filters
@@ -29,5 +29,9 @@
     <ClInclude Include="JsonConfig.h">
       <Filter>inc</Filter>
     </ClInclude>
+    <ClInclude Include="ArgRedirection.h">
+      <Filter>inc</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>
+

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -11,6 +11,7 @@
 #include <string_view>
 
 #include "win32_error.h"
+#include "known_folders.h"
 
 template <typename CharT>
 struct case_insensitive_char_traits : std::char_traits<CharT>
@@ -222,4 +223,49 @@ inline wide_argument_string_with_buffer widen_argument(const char* str)
 inline wide_argument_string widen_argument(const wchar_t* str) noexcept
 {
     return wide_argument_string{ str };
+}
+
+template <typename CharT>
+errno_t strcatImpl(CharT* dest, rsize_t destBufSize, CharT const* src)
+{
+    if (std::is_same<CharT, char>::value)
+    {
+        return strcat_s(reinterpret_cast<char*>(dest), destBufSize, reinterpret_cast<const char*>(src));
+    }
+    else
+    {
+        return wcscat_s(reinterpret_cast<wchar_t*>(dest), destBufSize, reinterpret_cast<const wchar_t*>(src));
+    }
+}
+
+template <typename CharT>
+CharT* strtokImpl(CharT* inpStr, CharT const* delim, CharT** token)
+{
+    if (std::is_same<CharT, char>::value)
+    {
+        return reinterpret_cast<CharT*>(strtok_s(reinterpret_cast<char*>(inpStr), reinterpret_cast<const char*>(delim), reinterpret_cast<char**>(token)));
+    }
+    else
+    {
+        return reinterpret_cast<CharT*>(wcstok_s(reinterpret_cast<wchar_t*>(inpStr), reinterpret_cast<const wchar_t*>(delim), reinterpret_cast<wchar_t**>(token)));
+    }
+}
+
+template <typename CharT>
+size_t strlenImpl(CharT const* inpStr)
+{
+    if (std::is_same<CharT, char>::value)
+    {
+        return strlen(reinterpret_cast<const char*>(inpStr));
+    }
+    else
+    {
+        return wcslen(reinterpret_cast<const wchar_t*>(inpStr));
+    }
+}
+
+template <typename CharT>
+bool is_path_relative(const CharT* path, const std::filesystem::path& basePath)
+{
+    return std::equal(basePath.native().begin(), basePath.native().end(), path, psf::path_compare{});
 }

--- a/tests/RunTests.ps1
+++ b/tests/RunTests.ps1
@@ -40,7 +40,7 @@ function RunTest($Arch, $Config)
     {
         # Uninstall all packages on exit. Ideally Add-AppxPackage would give us back something that we could use here,
         # but alas we must hard-code it
-        $packagesToUninstall = @("ArchitectureTest", "CompositionTest", "FileSystemTest", "LongPathsTest", "WorkingDirectoryTest", "PowershellScriptTest", "DynamicLibraryTest", "RegLegacyTest", "EnvVarsATest", "EnvVarsWTest")
+        $packagesToUninstall = @("ArchitectureTest", "CompositionTest", "FileSystemTest", "LongPathsTest", "WorkingDirectoryTest", "PowershellScriptTest", "DynamicLibraryTest", "RegLegacyTest", "EnvVarsATest", "EnvVarsWTest", "ArgRedirectionTest")
         foreach ($pkg in $packagesToUninstall)
         {
             Get-AppxPackage $pkg | Remove-AppxPackage

--- a/tests/TestRunner/main.cpp
+++ b/tests/TestRunner/main.cpp
@@ -42,7 +42,9 @@ static constexpr const wchar_t* g_applications[] =
     L"EnvVarsATest_8wekyb3d8bbwe!Fixed32",
     L"EnvVarsATest_8wekyb3d8bbwe!Fixed64",
     L"EnvVarsWTest_8wekyb3d8bbwe!Fixed32",
-    L"EnvVarsWTest_8wekyb3d8bbwe!Fixed64"
+    L"EnvVarsWTest_8wekyb3d8bbwe!Fixed64",
+    L"ArgRedirectionTest_8wekyb3d8bbwe!Fixed32",
+    L"ArgRedirectionTest_8wekyb3d8bbwe!Fixed64"
 };
 
 bool g_onlyPrintSummary = false;

--- a/tests/scenarios/ArgRedirectionTest/AppxManifest.xml
+++ b/tests/scenarios/ArgRedirectionTest/AppxManifest.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+         xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+         xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+         xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10">
+	<Identity Name="ArgRedirectionTest"
+			  Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+			  Version="0.0.0.1"
+			  ProcessorArchitecture="x64" />
+	<Properties>
+		<DisplayName>ArgRedirection Test</DisplayName>
+		<PublisherDisplayName>Reserved</PublisherDisplayName>
+		<Description>No description entered</Description>
+		<Logo>Assets\Logo44x44.png</Logo>
+	</Properties>
+	<Resources>
+		<Resource Language="en-us" />
+	</Resources>
+	<Dependencies>
+		<TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.14257.0" MaxVersionTested="10.0.14257.0" />
+	</Dependencies>
+	<Capabilities>
+		<rescap:Capability Name="runFullTrust" />
+	</Capabilities>
+	<Applications>
+		<Application Id="UnFixed64" Executable="ArgRedirectionTest.exe" EntryPoint="Windows.FullTrustApplication">
+			<uap:VisualElements BackgroundColor="transparent"
+								DisplayName="ArgRedirection Test (Un-Fixed x64)"
+								Square150x150Logo="Assets\Logo150x150.png"
+								Square44x44Logo="Assets\Logo44x44.png"
+								Description="No description entered" />
+		</Application>
+		<Application Id="UnFixed32" Executable="ArgRedirectionTest.exe" EntryPoint="Windows.FullTrustApplication">
+			<uap:VisualElements BackgroundColor="transparent"
+								DisplayName="ArgRedirection Test (Un-Fixed x86)"
+								Square150x150Logo="Assets\Logo150x150.png"
+								Square44x44Logo="Assets\Logo44x44.png"
+								Description="No description entered" />
+		</Application>
+		<Application Id="Fixed64" Executable="PsfLauncher.exe" EntryPoint="Windows.FullTrustApplication">
+			<uap:VisualElements BackgroundColor="transparent"
+								DisplayName="ArgRedirection Test (Un-Fixed x64)"
+								Square150x150Logo="Assets\Logo150x150.png"
+								Square44x44Logo="Assets\Logo44x44.png"
+								Description="No description entered" />
+		</Application>
+		<Application Id="Fixed32" Executable="PsfLauncher.exe" EntryPoint="Windows.FullTrustApplication">
+			<uap:VisualElements BackgroundColor="transparent"
+								DisplayName="ArgRedirection Test (Un-Fixed x86)"
+								Square150x150Logo="Assets\Logo150x150.png"
+								Square44x44Logo="Assets\Logo44x44.png"
+								Description="No description entered" />
+		</Application>
+	</Applications>
+</Package>

--- a/tests/scenarios/ArgRedirectionTest/ArgRedirectionTest.vcxproj
+++ b/tests/scenarios/ArgRedirectionTest/ArgRedirectionTest.vcxproj
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{5aa28a28-6be4-46e8-89c4-794137bbfeda}</ProjectGuid>
+    <RootNamespace>ArgRedirectionTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\common</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\common</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\common</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\common</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Xml Include="AppxManifest.xml" />
+	<Xml Include="config.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="FileMapping.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="config.json" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/tests/scenarios/ArgRedirectionTest/ArgRedirectionTest.vcxproj.filters
+++ b/tests/scenarios/ArgRedirectionTest/ArgRedirectionTest.vcxproj.filters
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+	  <Xml Include="AppxManifest.xml">
+		  <Filter>pkg</Filter>
+	  </Xml>
+	  <Xml Include="config.xml">
+		  <Filter>pkg</Filter>
+	  </Xml>
+  </ItemGroup>
+  <ItemGroup>
+	  <Text Include="FileMapping.txt">
+		  <Filter>pkg</Filter>
+	  </Text>
+  </ItemGroup>
+  <ItemGroup>
+	  <None Include="config.json">
+		  <Filter>pkg</Filter>
+	  </None>
+  </ItemGroup>
+</Project>

--- a/tests/scenarios/ArgRedirectionTest/FileMapping.txt
+++ b/tests/scenarios/ArgRedirectionTest/FileMapping.txt
@@ -1,0 +1,11 @@
+[Files]
+"AppxManifest.xml" "AppxManifest.xml"
+"config.json" "config.json"
+
+"..\..\${Architecture}${Configuration}\ArgRedirectionTest.exe" "ArgRedirectionTest.exe"
+
+"..\..\..\${Architecture}${Configuration}\PsfLauncher${Bitness}.exe" "PsfLauncher.exe"
+"..\..\..\${Architecture}${Configuration}\PsfRuntime${Bitness}.dll" "PsfRuntime${Bitness}.dll"
+
+"..\Assets\Logo44x44.png" "Assets\Logo44x44.png"
+"..\Assets\Logo150x150.png" "Assets\Logo150x150.png"

--- a/tests/scenarios/ArgRedirectionTest/config.json
+++ b/tests/scenarios/ArgRedirectionTest/config.json
@@ -1,0 +1,13 @@
+{
+  "applications": [
+    {
+      "id": "Fixed64",
+      "executable": "ArgRedirectionTest.exe"
+    },
+    {
+      "id": "Fixed32",
+      "executable": "ArgRedirectionTest.exe"
+    }
+
+  ]
+}

--- a/tests/scenarios/ArgRedirectionTest/config.xml
+++ b/tests/scenarios/ArgRedirectionTest/config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<applications>
+		<application>
+			<id>Fixed32</id>
+			<executable>ArgRedirectionTest.exe</executable>
+		</application>
+		<application>
+			<id>Fixed64</id>
+			<executable>ArgRedirectionTest.exe</executable>
+		</application>
+	</applications>
+</configuration>

--- a/tests/scenarios/ArgRedirectionTest/main.cpp
+++ b/tests/scenarios/ArgRedirectionTest/main.cpp
@@ -1,0 +1,130 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include <windows.h>
+#include <ShlObj.h>
+
+#include <test_config.h>
+#include <known_folders.h>
+#include <psf_utils.h>
+
+int wmain(int argc, const wchar_t** argv)
+{
+    auto result = parse_args(argc, argv);
+    if (result != ERROR_SUCCESS)
+    {
+        return result;
+    }
+    test_initialize("Argument Redirection Tests", 2);
+
+    test_begin("Arg Redirection Test - CreateProcessA, LocalAppData");
+    {
+        result = ERROR_SUCCESS;
+        auto newAppFolder_Local = psf::known_folder(FOLDERID_LocalAppData) / std::filesystem::path(L"Packages") / psf::current_package_family_name() / LR"(LocalCache\Local\ArgRedirectionTest)";
+        CreateDirectoryW(newAppFolder_Local.c_str(), NULL);
+
+        // create a file in per user per app data
+        auto newFile_packageLocalAppDataPath = psf::known_folder(FOLDERID_LocalAppData) / std::filesystem::path(L"Packages") / psf::current_package_family_name() / LR"(LocalCache\Local\ArgRedirectionTest\newFile.txt)";
+        HANDLE hFile = ::CreateFileW(newFile_packageLocalAppDataPath.c_str(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_WRITE,
+            NULL,
+            CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL,
+            NULL);
+        CloseHandle(hFile);
+
+        // Launch a cmd.exe application to rename newFile.txt in app data location
+        STARTUPINFOA si;
+        PROCESS_INFORMATION pi;
+        ZeroMemory(&si, sizeof(si));
+        si.cb = sizeof(si);
+        ZeroMemory(&pi, sizeof(pi));
+
+        char cmdLineArg[MAX_PATH] = "C:\\Windows\\System32\\cmd.exe /c ren ";
+        char appDataPath[MAX_PATH];
+        SHGetFolderPathA(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, appDataPath);
+        strcat_s(appDataPath, MAX_PATH, "\\ArgRedirectionTest\\newFile.txt"); // dest
+        strcat_s(cmdLineArg, appDataPath);
+        strcat_s(cmdLineArg, " newFile_renamed.txt");
+        BOOL procRes = ::CreateProcessA(NULL, (char*)cmdLineArg, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
+
+        if (procRes != 0)
+        {
+            CloseHandle(pi.hProcess);
+            CloseHandle(pi.hThread);
+        }
+        Sleep(1000); // sleep for 1sec for renamed file to be reflected
+
+        // check if the renamed file exists in per user per app data location
+        auto dest_file = psf::known_folder(FOLDERID_LocalAppData) / std::filesystem::path(L"Packages") / psf::current_package_family_name() / LR"(LocalCache\Local\ArgRedirectionTest\newFile_renamed.txt)";
+        if (GetFileAttributesW(dest_file.c_str()) == INVALID_FILE_ATTRIBUTES)
+        {
+            result = ERROR_FILE_NOT_FOUND;
+        }
+        else
+        {
+            DeleteFileW(dest_file.c_str());
+            RemoveDirectory(newAppFolder_Local.c_str());
+        }
+    }
+    test_end(result);
+
+    test_begin("Arg Redirection Test - CreateProcessW, RoamingAppData");
+    {
+        result = ERROR_SUCCESS;
+        auto newAppFolder_Roaming = psf::known_folder(FOLDERID_LocalAppData) / std::filesystem::path(L"Packages") / psf::current_package_family_name() / LR"(LocalCache\Roaming\ArgRedirectionTest)";
+        CreateDirectoryW(newAppFolder_Roaming.c_str(), NULL);
+
+        // create a file in per user per app data
+        auto newFile_packageRoamingAppDataPath = psf::known_folder(FOLDERID_LocalAppData) / std::filesystem::path(L"Packages") / psf::current_package_family_name() / LR"(LocalCache\Roaming\ArgRedirectionTest\newFile.txt)";
+        HANDLE hFile = ::CreateFileW(newFile_packageRoamingAppDataPath.c_str(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_WRITE,
+            NULL,
+            CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL,
+            NULL);
+        CloseHandle(hFile);
+
+        // Launch a cmd.exe application to rename notepad.exe in app data location
+        STARTUPINFO si;
+        PROCESS_INFORMATION pi;
+        ZeroMemory(&si, sizeof(si));
+        si.cb = sizeof(si);
+        ZeroMemory(&pi, sizeof(pi));
+
+        wchar_t cmdLineArg[MAX_PATH] = L"C:\\Windows\\System32\\cmd.exe /c ren ";
+        wchar_t appDataPath[MAX_PATH];
+        SHGetFolderPath(NULL, CSIDL_APPDATA | CSIDL_FLAG_CREATE, NULL, SHGFP_TYPE_CURRENT, appDataPath);
+        wcscat_s(appDataPath, MAX_PATH, L"\\ArgRedirectionTest\\newFile.txt"); // dest
+        wcscat_s(cmdLineArg, appDataPath);
+        wcscat_s(cmdLineArg, L" newFile_renamed.txt");
+        BOOL procRes = ::CreateProcessW(NULL, cmdLineArg, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
+
+        if (procRes != 0)
+        {
+            CloseHandle(pi.hProcess);
+            CloseHandle(pi.hThread);
+        }
+        Sleep(1000); // sleep for 1sec for renamed file to be reflected
+
+        // check if the renamed file exists in per user per app data location
+        auto dest_file = psf::known_folder(FOLDERID_LocalAppData) / std::filesystem::path(L"Packages") / psf::current_package_family_name() / LR"(LocalCache\Roaming\ArgRedirectionTest\newFile_renamed.txt)";
+        if (GetFileAttributesW(dest_file.c_str()) == INVALID_FILE_ATTRIBUTES)
+        {
+            result = ERROR_FILE_NOT_FOUND;
+        }
+        else
+        {
+            DeleteFileW(dest_file.c_str());
+            RemoveDirectory(newAppFolder_Roaming.c_str());
+        }
+    }
+    test_end(result);
+
+    test_cleanup();
+    return result;
+}

--- a/tests/scenarios/ArgRedirectionTest/x64Debug/FileMapping.txt
+++ b/tests/scenarios/ArgRedirectionTest/x64Debug/FileMapping.txt
@@ -1,0 +1,12 @@
+[Files]
+"AppxManifest.xml" "AppxManifest.xml"
+"config.json" "config.json"
+
+"..\..\x64\Debug\ArgRedirectionTest.exe" "ArgRedirectionTest.exe"
+
+"..\..\..\x64\Debug\PsfLauncher64.exe" "PsfLauncher.exe"
+"..\..\..\x64\Debug\PsfRuntime64.dll" "PsfRuntime64.dll"
+
+
+"..\Assets\Logo44x44.png" "Assets\Logo44x44.png"
+"..\Assets\Logo150x150.png" "Assets\Logo150x150.png"

--- a/tests/scenarios/ArgRedirectionTest/x64Release/FileMapping.txt
+++ b/tests/scenarios/ArgRedirectionTest/x64Release/FileMapping.txt
@@ -1,0 +1,11 @@
+[Files]
+"AppxManifest.xml" "AppxManifest.xml"
+"config.json" "config.json"
+
+"..\..\x64\Release\ArgRedirectionTest.exe" "ArgRedirectionTest.exe"
+
+"..\..\..\x64\Release\PsfLauncher64.exe" "PsfLauncher.exe"
+"..\..\..\x64\Release\PsfRuntime64.dll" "PsfRuntime64.dll"
+
+"..\Assets\Logo44x44.png" "Assets\Logo44x44.png"
+"..\Assets\Logo150x150.png" "Assets\Logo150x150.png"

--- a/tests/scenarios/ArgRedirectionTest/x86Debug/FileMapping.txt
+++ b/tests/scenarios/ArgRedirectionTest/x86Debug/FileMapping.txt
@@ -1,0 +1,11 @@
+[Files]
+"AppxManifest.xml" "AppxManifest.xml"
+"config.json" "config.json"
+
+"..\..\Win32\Debug\ArgRedirectionTest.exe" "ArgRedirectionTest.exe"
+
+"..\..\..\Win32\Debug\PsfLauncher32.exe" "PsfLauncher.exe"
+"..\..\..\Win32\Debug\PsfRuntime32.dll" "PsfRuntime32.dll"
+
+"..\Assets\Logo44x44.png" "Assets\Logo44x44.png"
+"..\Assets\Logo150x150.png" "Assets\Logo150x150.png"

--- a/tests/scenarios/ArgRedirectionTest/x86Release/FileMapping.txt
+++ b/tests/scenarios/ArgRedirectionTest/x86Release/FileMapping.txt
@@ -1,0 +1,11 @@
+[Files]
+"AppxManifest.xml" "AppxManifest.xml"
+"config.json" "config.json"
+
+"..\..\Win32\Release\ArgRedirectionTest.exe" "ArgRedirectionTest.exe"
+
+"..\..\..\Win32\Release\PsfLauncher32.exe" "PsfLauncher.exe"
+"..\..\..\Win32\Release\PsfRuntime32.dll" "PsfRuntime32.dll"
+
+"..\Assets\Logo44x44.png" "Assets\Logo44x44.png"
+"..\Assets\Logo150x150.png" "Assets\Logo150x150.png"

--- a/tests/tests.sln
+++ b/tests/tests.sln
@@ -27,6 +27,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "EnvVarsATest", "scenarios\E
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "EnvVarsWTest", "scenarios\EnvVarsWTest\EnvVarsWTest.vcxproj", "{9585E26E-F1D0-4199-B07F-A46257327CA9}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ArgRedirectionTest", "scenarios\ArgRedirectionTest\ArgRedirectionTest.vcxproj", "{5AA28A28-6BE4-46E8-89C4-794137BBFEDA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -123,6 +125,14 @@ Global
 		{9585E26E-F1D0-4199-B07F-A46257327CA9}.Release|x64.Build.0 = Release|x64
 		{9585E26E-F1D0-4199-B07F-A46257327CA9}.Release|x86.ActiveCfg = Release|Win32
 		{9585E26E-F1D0-4199-B07F-A46257327CA9}.Release|x86.Build.0 = Release|Win32
+		{5AA28A28-6BE4-46E8-89C4-794137BBFEDA}.Debug|x64.ActiveCfg = Debug|x64
+		{5AA28A28-6BE4-46E8-89C4-794137BBFEDA}.Debug|x64.Build.0 = Debug|x64
+		{5AA28A28-6BE4-46E8-89C4-794137BBFEDA}.Debug|x86.ActiveCfg = Debug|Win32
+		{5AA28A28-6BE4-46E8-89C4-794137BBFEDA}.Debug|x86.Build.0 = Debug|Win32
+		{5AA28A28-6BE4-46E8-89C4-794137BBFEDA}.Release|x64.ActiveCfg = Release|x64
+		{5AA28A28-6BE4-46E8-89C4-794137BBFEDA}.Release|x64.Build.0 = Release|x64
+		{5AA28A28-6BE4-46E8-89C4-794137BBFEDA}.Release|x86.ActiveCfg = Release|Win32
+		{5AA28A28-6BE4-46E8-89C4-794137BBFEDA}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -138,6 +148,7 @@ Global
 		{90719DF5-F8FC-49DF-B7C7-75EB247D9E8D} = {51D2A935-9355-4DFD-882C-2FE3F39CB4CC}
 		{434BCA70-2E41-4BE4-A030-92A5D351800E} = {51D2A935-9355-4DFD-882C-2FE3F39CB4CC}
 		{9585E26E-F1D0-4199-B07F-A46257327CA9} = {51D2A935-9355-4DFD-882C-2FE3F39CB4CC}
+		{5AA28A28-6BE4-46E8-89C4-794137BBFEDA} = {51D2A935-9355-4DFD-882C-2FE3F39CB4CC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3873DE95-AB16-4C4B-848A-1BCE9BD8444F}


### PR DESCRIPTION
## Why is this change being made?
When an external (to the container) process is launched with arguments including appData path, these are not virtualized and in turn application tries to access files in native app data path instead of per user per app data path because of which it fails to find it.

## What changed?
This feature handles redirecting createProcess argument calls from native app data to per user per app data when corresponding files are found in per user per appdata file.

## How was the change tested?
-A test application is added which triggers cmd.exe(C:\Windows\System32\cmd.exe) to rename an existing file in appdata
folder (passed as a parameter). Renaming would be successful when Argument is redirected to per user per appdata folder.