### PR TITLE
Powershell startScript/EndScript  error handling

### DIFF
--- a/PsfLauncher/PsfPowershellScriptRunner.h
+++ b/PsfLauncher/PsfPowershellScriptRunner.h
@@ -198,15 +198,16 @@ private:
 			std::thread pwrShellThread = std::thread(StartProcess, nullptr, script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeList.get(), &exitCode);
 			pwrShellThread.detach();
 		}
+
 		DWORD execPolicyFailExitCode = 0x01;
 		if (exitCode == execPolicyFailExitCode)
 		{
-			MessageBoxEx(NULL, (script.scriptPath + std::wstring(L" execution faildue to an execution policy restriction. To run the script, you may need to change the execution policy. For more information, see about_Execution_Policies at https://go.microsoft.com/fwlink/?LinkID=135170.  ")).c_str(), L"Warning", MB_OK | MB_ICONWARNING, 0);
+			MessageBoxEx(NULL, (script.scriptPath + std::wstring(L" failed due to an execution policy restriction. To change the executing policy, execute \"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine\" and re-run the application.")).c_str(), L"Package Support Framework", MB_OK | MB_ICONWARNING, 0);
 		}
-		else if (exitCode != ERROR_SUCCESS)
+		else if (exitCode != ERROR_SUCCESS) 
 		{
 			std::wstring exitCodeStr = std::to_wstring(exitCode);
-			MessageBoxEx(NULL, (script.scriptPath + std::wstring(L" execution fails. ExitCode:  ") + exitCodeStr).c_str(), L"Warning", MB_OK | MB_ICONWARNING, 0);
+			MessageBoxEx(NULL, (script.scriptPath + std::wstring(L" execution failed with Exit Code ") + exitCodeStr + std::wstring(L". To fix this, please run ") + script.scriptPath + std::wstring(L" standalone in a PowerShell window and confirm that the value of $LASTEXITCODE is 0 (Success) before using it with PSF.")).c_str(), L"Package Support Framework", MB_OK | MB_ICONWARNING, 0);
 		}
 	}
 

--- a/PsfLauncher/PsfPowershellScriptRunner.h
+++ b/PsfLauncher/PsfPowershellScriptRunner.h
@@ -182,9 +182,10 @@ private:
 			return;
 		}
 
+		DWORD exitCode = ERROR_SUCCESS;
 		if (script.waitForScriptToFinish)
 		{
-			HRESULT startScriptResult = StartProcess(nullptr, script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeList.get());
+			HRESULT startScriptResult = StartProcess(nullptr, script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeList.get(), &exitCode);
 
 			if (script.stopOnScriptError)
 			{
@@ -194,8 +195,18 @@ private:
 		else
 		{
 			//We don't want to stop on an error and we want to run async
-			std::thread pwrShellThread = std::thread(StartProcess, nullptr, script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeList.get());
+			std::thread pwrShellThread = std::thread(StartProcess, nullptr, script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeList.get(), &exitCode);
 			pwrShellThread.detach();
+		}
+		DWORD execPolicyFailExitCode = 0x01;
+		if (exitCode == execPolicyFailExitCode)
+		{
+			MessageBoxEx(NULL, (script.scriptPath + std::wstring(L" execution faildue to an execution policy restriction. To run the script, you may need to change the execution policy. For more information, see about_Execution_Policies at https://go.microsoft.com/fwlink/?LinkID=135170.  ")).c_str(), L"Warning", MB_OK | MB_ICONWARNING, 0);
+		}
+		else if (exitCode != ERROR_SUCCESS)
+		{
+			std::wstring exitCodeStr = std::to_wstring(exitCode);
+			MessageBoxEx(NULL, (script.scriptPath + std::wstring(L" execution fails. ExitCode:  ") + exitCodeStr).c_str(), L"Warning", MB_OK | MB_ICONWARNING, 0);
 		}
 	}
 

--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -48,15 +48,14 @@ HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR curren
         "ERROR: Failed to create a process for %ws",
         applicationName);
 
-    if (exitCode != nullptr)
-    {
-        WaitForSingleObject(processInfo.hProcess, INFINITE);
-        GetExitCodeProcess(processInfo.hProcess, exitCode);
-    }
 
     RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE), processInfo.hProcess == INVALID_HANDLE_VALUE);
     DWORD waitResult = ::WaitForSingleObject(processInfo.hProcess, timeout);
     RETURN_LAST_ERROR_IF_MSG(waitResult != WAIT_OBJECT_0, "Waiting operation failed unexpectedly.");
+    if (exitCode != nullptr)
+    {
+        GetExitCodeProcess(processInfo.hProcess, exitCode);
+    }
     CloseHandle(processInfo.hProcess);
     CloseHandle(processInfo.hThread);
 

--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -4,7 +4,7 @@
 #include "Globals.h"
 #include <wil\resource.h>
 
-HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR currentDirectory, int cmdShow, DWORD timeout, LPPROC_THREAD_ATTRIBUTE_LIST attributeList = nullptr)
+HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR currentDirectory, int cmdShow, DWORD timeout, LPPROC_THREAD_ATTRIBUTE_LIST attributeList = nullptr, DWORD *exitCode = nullptr)
 {
 
     STARTUPINFOEXW startupInfoEx =
@@ -25,7 +25,6 @@ HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR curren
         , static_cast<WORD>(cmdShow) // wShowWindow
         }
     };
-
     PROCESS_INFORMATION processInfo{};
 
     startupInfoEx.lpAttributeList = attributeList;
@@ -48,6 +47,12 @@ HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR curren
             &processInfo),
         "ERROR: Failed to create a process for %ws",
         applicationName);
+
+    if (exitCode != nullptr)
+    {
+        WaitForSingleObject(processInfo.hProcess, INFINITE);
+        GetExitCodeProcess(processInfo.hProcess, exitCode);
+    }
 
     RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE), processInfo.hProcess == INVALID_HANDLE_VALUE);
     DWORD waitResult = ::WaitForSingleObject(processInfo.hProcess, timeout);

--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -4,7 +4,7 @@
 #include "Globals.h"
 #include <wil\resource.h>
 
-HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR currentDirectory, int cmdShow, DWORD timeout, LPPROC_THREAD_ATTRIBUTE_LIST attributeList = nullptr, DWORD *exitCode = nullptr)
+HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR currentDirectory, int cmdShow, DWORD timeout, LPPROC_THREAD_ATTRIBUTE_LIST attributeList = nullptr, _Out_ DWORD *exitCode = nullptr)
 {
 
     STARTUPINFOEXW startupInfoEx =


### PR DESCRIPTION
## Why is this change being made?
When startScript or EndScript mentioned in config.json fails to run either due to execution policy for powershell not set correctly or due to any other reason, there is no warning message displayed to user and user would not know whether the mentioned script is run successfully or not.

## What changed?
A warning popup message is displayed to user when startScript/EndScript fails to run mentioning the exitCode. If the exitCode matches with execution policy related failure, a detailed warning message is displayed mentioning the error and how user could reset execution policy

## How was the change tested?
It was manually tested loading startScript in an application and confirming that a popup warning is displayed when powershell execution policy is set to Restricted.