### PR TITLE
Powershell first launch fix

### DIFF
--- a/PsfLauncher/PsfPowershellScriptRunner.h
+++ b/PsfLauncher/PsfPowershellScriptRunner.h
@@ -198,15 +198,16 @@ private:
 			std::thread pwrShellThread = std::thread(StartProcess, nullptr, script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeList.get(), &exitCode);
 			pwrShellThread.detach();
 		}
+
 		DWORD execPolicyFailExitCode = 0x01;
 		if (exitCode == execPolicyFailExitCode)
 		{
-			MessageBoxEx(NULL, (script.scriptPath + std::wstring(L" execution faildue to an execution policy restriction. To run the script, you may need to change the execution policy. For more information, see about_Execution_Policies at https://go.microsoft.com/fwlink/?LinkID=135170.  ")).c_str(), L"Warning", MB_OK | MB_ICONWARNING, 0);
+			MessageBoxEx(NULL, (script.scriptPath + std::wstring(L" failed due to an execution policy restriction. To change the executing policy, execute \"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine\" and re-run the application.")).c_str(), L"Package Support Framework", MB_OK | MB_ICONWARNING, 0);
 		}
-		else if (exitCode != ERROR_SUCCESS)
+		else if (exitCode != ERROR_SUCCESS) 
 		{
 			std::wstring exitCodeStr = std::to_wstring(exitCode);
-			MessageBoxEx(NULL, (script.scriptPath + std::wstring(L" execution fails. ExitCode:  ") + exitCodeStr).c_str(), L"Warning", MB_OK | MB_ICONWARNING, 0);
+			MessageBoxEx(NULL, (script.scriptPath + std::wstring(L" execution failed with Exit Code ") + exitCodeStr + std::wstring(L". To fix this, please run ") + script.scriptPath + std::wstring(L" standalone in a PowerShell window and confirm that the value of $LASTEXITCODE is 0 (Success) before using it with PSF.")).c_str(), L"Package Support Framework", MB_OK | MB_ICONWARNING, 0);
 		}
 	}
 

--- a/PsfLauncher/PsfPowershellScriptRunner.h
+++ b/PsfLauncher/PsfPowershellScriptRunner.h
@@ -182,9 +182,10 @@ private:
 			return;
 		}
 
+		DWORD exitCode = ERROR_SUCCESS;
 		if (script.waitForScriptToFinish)
 		{
-			HRESULT startScriptResult = StartProcess(nullptr, script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeList.get());
+			HRESULT startScriptResult = StartProcess(nullptr, script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeList.get(), &exitCode);
 
 			if (script.stopOnScriptError)
 			{
@@ -194,8 +195,18 @@ private:
 		else
 		{
 			//We don't want to stop on an error and we want to run async
-			std::thread pwrShellThread = std::thread(StartProcess, nullptr, script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeList.get());
+			std::thread pwrShellThread = std::thread(StartProcess, nullptr, script.commandString.data(), script.currentDirectory.c_str(), script.showWindowAction, script.timeout, m_AttributeList.get(), &exitCode);
 			pwrShellThread.detach();
+		}
+		DWORD execPolicyFailExitCode = 0x01;
+		if (exitCode == execPolicyFailExitCode)
+		{
+			MessageBoxEx(NULL, (script.scriptPath + std::wstring(L" execution faildue to an execution policy restriction. To run the script, you may need to change the execution policy. For more information, see about_Execution_Policies at https://go.microsoft.com/fwlink/?LinkID=135170.  ")).c_str(), L"Warning", MB_OK | MB_ICONWARNING, 0);
+		}
+		else if (exitCode != ERROR_SUCCESS)
+		{
+			std::wstring exitCodeStr = std::to_wstring(exitCode);
+			MessageBoxEx(NULL, (script.scriptPath + std::wstring(L" execution fails. ExitCode:  ") + exitCodeStr).c_str(), L"Warning", MB_OK | MB_ICONWARNING, 0);
 		}
 	}
 

--- a/PsfLauncher/Readme.md
+++ b/PsfLauncher/Readme.md
@@ -307,12 +307,12 @@ The use of scriptExecutionMode may only be necessary in environments when Group 
 | applications | startScript | (Optional) If present, used to define a PowerShell script that will be run prior running the application executable. |
 | | |  `'waitForScriptToFinish'` - (Optional, default=true) Boolean. When true, PsfLauncher will wait for the script to complete or timeout before running the application executable. |
 | | | `'timeout'` - (Optional, default is none) Expressed in ms.  Only applicable if waitForScriptToFinish is true.  If a timeout occurs it is treated as an error for the purpose of `'stopOnScriptError'`. The value 0 means an immediate timeout, if you do not want a timeout do not specify a value. |
-| | | `'runOnce'` - (Optional, default=false) Boolean. When true, the script will only be run the first time the user runs the application. |
+| | | `'runOnce'` - (Optional, default=true) Boolean. When true, the script will only be run the first time the user runs the application. If script fails to run, it will be run on every launch of application till it runs successfully once. |
 | | | `'showWindow'` - (Optional, default=true). Boolean. When false, the PowerShell window is hidden. |
 | | | `'scriptPath'` - Relative or full path to a ps1 file. May be in package or on a network share. Use of pseudo-variables or environment variables are supported. |
 | | | `'scriptArguments'` - (Optional) Arguments for the `'scriptPath'` PowerShell file.  Use of pseudo-variables or environment variables are supported. Multiple arguments(and arguments with space) are provided by enclosing each argument in single quote. ("scriptArguments": "'<Arg1>' '<Arg2>'"). |
 | applications | endScript | (Optional) If present, used to define a PowerShell script that will be run after completion of the application executable. |
-| | | `'runOnce'` - (Optional, default=false) Boolean. When true, the script will only be run the first time the user runs the application. |
+| | | `'runOnce'` - (Optional, default=true) Boolean. When true, the script will only be run the first time the user runs the application. If script fails to run, it will be run on every launch of application till it runs successfully once. |
 | | | `'showWindow'` - (Optional, default=true). Boolean. When false, the PowerShell window is hidden. |
 | | | `'scriptPath'` - Relative or full path to a ps1 file. May be in package or on a network share. Use of pseudo-variables or environment variables are supported. |
 | | | `'scriptArguments'` - (Optional) Arguments for the `'scriptPath'` PowerShell file.  Use of pseudo-variables or environment variables are supported. |

--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -48,15 +48,14 @@ HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR curren
         "ERROR: Failed to create a process for %ws",
         applicationName);
 
-    if (exitCode != nullptr)
-    {
-        WaitForSingleObject(processInfo.hProcess, INFINITE);
-        GetExitCodeProcess(processInfo.hProcess, exitCode);
-    }
 
     RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE), processInfo.hProcess == INVALID_HANDLE_VALUE);
     DWORD waitResult = ::WaitForSingleObject(processInfo.hProcess, timeout);
     RETURN_LAST_ERROR_IF_MSG(waitResult != WAIT_OBJECT_0, "Waiting operation failed unexpectedly.");
+    if (exitCode != nullptr)
+    {
+        GetExitCodeProcess(processInfo.hProcess, exitCode);
+    }
     CloseHandle(processInfo.hProcess);
     CloseHandle(processInfo.hThread);
 

--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -4,7 +4,7 @@
 #include "Globals.h"
 #include <wil\resource.h>
 
-HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR currentDirectory, int cmdShow, DWORD timeout, LPPROC_THREAD_ATTRIBUTE_LIST attributeList = nullptr)
+HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR currentDirectory, int cmdShow, DWORD timeout, LPPROC_THREAD_ATTRIBUTE_LIST attributeList = nullptr, DWORD *exitCode = nullptr)
 {
 
     STARTUPINFOEXW startupInfoEx =
@@ -25,7 +25,6 @@ HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR curren
         , static_cast<WORD>(cmdShow) // wShowWindow
         }
     };
-
     PROCESS_INFORMATION processInfo{};
 
     startupInfoEx.lpAttributeList = attributeList;
@@ -48,6 +47,12 @@ HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR curren
             &processInfo),
         "ERROR: Failed to create a process for %ws",
         applicationName);
+
+    if (exitCode != nullptr)
+    {
+        WaitForSingleObject(processInfo.hProcess, INFINITE);
+        GetExitCodeProcess(processInfo.hProcess, exitCode);
+    }
 
     RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE), processInfo.hProcess == INVALID_HANDLE_VALUE);
     DWORD waitResult = ::WaitForSingleObject(processInfo.hProcess, timeout);

--- a/PsfLauncher/StartProcessHelper.h
+++ b/PsfLauncher/StartProcessHelper.h
@@ -4,7 +4,7 @@
 #include "Globals.h"
 #include <wil\resource.h>
 
-HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR currentDirectory, int cmdShow, DWORD timeout, LPPROC_THREAD_ATTRIBUTE_LIST attributeList = nullptr, DWORD *exitCode = nullptr)
+HRESULT StartProcess(LPCWSTR applicationName, LPWSTR commandLine, LPCWSTR currentDirectory, int cmdShow, DWORD timeout, LPPROC_THREAD_ATTRIBUTE_LIST attributeList = nullptr, _Out_ DWORD *exitCode = nullptr)
 {
 
     STARTUPINFOEXW startupInfoEx =


### PR DESCRIPTION
## Why is this change being made?
When "runOnce" is set in config, powershell runs only on first launch of the application. But, if powershell fails to run due to any reason on first launch (one reason could be powershell policy not set on device correctly), script would not be run on the subsequent launch (although the issue is identified and fixed). This would force the users to re-install the application although it need not be required. (Unless in the cases when powershell script itself has to be modified to fix the issue)

## What changed?
-firstRun status of Powershell is reset until the powershell script runs successfully once. 
The registry key 'PSFScriptHasRun' which is used to capture first run of powerShell is deleted in application package hive till powerShell script runs successfully.
-Documentation of 'runOnce' is updated.

## How was the change tested?
It was manually tested by setting powershell execution policy on device to restricted and making sure powershell script runs even on subsequent launches of the application till execution policy issue is set to RemoteSigned/Bypass