### PR TITLE
Error messages for config.json and StartingScriptWrapper.ps1

### DIFF
--- a/PsfLauncher/PsfPowershellScriptRunner.h
+++ b/PsfLauncher/PsfPowershellScriptRunner.h
@@ -269,6 +269,10 @@ private:
 					SSWrapper = file.path();
 				}
 			}
+			if (!std::filesystem::exists(SSWrapper))
+			{
+				MessageBoxEx(NULL, L"'StartingScriptWrapper.ps1' was not found. This is required to run the PowerShell scripts through PSF. Kindly add it under the package root folder and re-install the application.", L"MSIX Packet Support Framework", MB_OK | MB_ICONWARNING, 0);
+			}
 		}
 		std::wstring commandString = L"Powershell.exe ";
 		commandString.append(scriptExecutionMode);

--- a/PsfLauncher/PsfPowershellScriptRunner.h
+++ b/PsfLauncher/PsfPowershellScriptRunner.h
@@ -271,7 +271,7 @@ private:
 			}
 			if (!std::filesystem::exists(SSWrapper))
 			{
-				MessageBoxEx(NULL, L"'StartingScriptWrapper.ps1' was not found. This is required to run the PowerShell scripts through PSF. Kindly add it under the package root folder and re-install the application.", L"MSIX Packet Support Framework", MB_OK | MB_ICONWARNING, 0);
+				MessageBoxEx(NULL, L"'StartingScriptWrapper.ps1' was not found. This is required to run the PowerShell scripts through PSF. We recommend you to add it under the package root folder and re-install the application.", L"MSIX Packet Support Framework", MB_OK | MB_ICONWARNING, 0);
 			}
 		}
 		std::wstring commandString = L"Powershell.exe ";

--- a/PsfLauncher/PsfPowershellScriptRunner.h
+++ b/PsfLauncher/PsfPowershellScriptRunner.h
@@ -269,9 +269,10 @@ private:
 					SSWrapper = file.path();
 				}
 			}
+
 			if (!std::filesystem::exists(SSWrapper))
-			{
-				MessageBoxEx(NULL, L"'StartingScriptWrapper.ps1' was not found. This is required to run the PowerShell scripts through PSF. We recommend you to add it under the package root folder and re-install the application.", L"MSIX Packet Support Framework", MB_OK | MB_ICONWARNING, 0);
+			{				
+				MessageBoxEx(NULL, L"'StartingScriptWrapper.ps1' was not found. This is required to run the PowerShell scripts through PSF. The app might continue to run but not behave as expected. Kindly add it inside the package and re-install the application.", L"MSIX Packet Support Framework", MB_OK | MB_ICONWARNING, 0);
 			}
 		}
 		std::wstring commandString = L"Powershell.exe ";

--- a/PsfRuntime/Config.cpp
+++ b/PsfRuntime/Config.cpp
@@ -299,6 +299,12 @@ void load_json()
                 }
             }
         }
+        if (!file)
+        {
+            MessageBoxEx(NULL, L"‘Config.json’ was not found. Kindly add it under the package root folder and re-install the application.", L"MSIX Packet Support Framework", MB_OK | MB_ICONERROR, 0);
+            psf::TraceLogExceptions("PSFConfigException", "config.json was not found");
+            return;
+        }
     }
 
 

--- a/PsfRuntime/Config.cpp
+++ b/PsfRuntime/Config.cpp
@@ -303,6 +303,7 @@ void load_json()
         {
             MessageBoxEx(NULL, L"'Config.json' was not found. We recommend you to add it under the package root folder and re-install the application.", L"MSIX Packet Support Framework", MB_OK | MB_ICONERROR, 0);
             psf::TraceLogExceptions("PSFConfigException", "config.json was not found");
+            Log("config.json was not found");
             return;
         }
     }

--- a/PsfRuntime/Config.cpp
+++ b/PsfRuntime/Config.cpp
@@ -299,12 +299,12 @@ void load_json()
                 }
             }
         }
+
         if (!file)
         {
-            MessageBoxEx(NULL, L"'Config.json' was not found. We recommend you to add it under the package root folder and re-install the application.", L"MSIX Packet Support Framework", MB_OK | MB_ICONERROR, 0);
             psf::TraceLogExceptions("PSFConfigException", "config.json was not found");
             Log("config.json was not found");
-            return;
+            throw std::runtime_error("'Config.json' was not found. Kindly add it inside the package and re-install the application.");
         }
     }
 

--- a/PsfRuntime/Config.cpp
+++ b/PsfRuntime/Config.cpp
@@ -301,7 +301,7 @@ void load_json()
         }
         if (!file)
         {
-            MessageBoxEx(NULL, L"‘Config.json’ was not found. Kindly add it under the package root folder and re-install the application.", L"MSIX Packet Support Framework", MB_OK | MB_ICONERROR, 0);
+            MessageBoxEx(NULL, L"'Config.json' was not found. We recommend you to add it under the package root folder and re-install the application.", L"MSIX Packet Support Framework", MB_OK | MB_ICONERROR, 0);
             psf::TraceLogExceptions("PSFConfigException", "config.json was not found");
             return;
         }

--- a/PsfRuntime/main.cpp
+++ b/PsfRuntime/main.cpp
@@ -263,6 +263,6 @@ catch (...)
     ::PSFReportError(widen(message_from_caught_exception()).c_str());
     ::SetLastError(win32_from_caught_exception());
     psf::TraceLogExceptions("PSFRuntimeException", widen(message_from_caught_exception()).c_str());
-    TraceLoggingRegister(g_Log_ETW_ComponentProvider);
+    TraceLoggingUnregister(g_Log_ETW_ComponentProvider);
     return false;
 }


### PR DESCRIPTION
## Why is this change being made? 
When PSF is applied to an MSIX application and if config.json is not added, proper error popup is not shown to user which might cause confusion to user in figuring out why the application fails to launch.

When user tries to execute power shell script through PSF, it is mandatory to include 'StartingScriptWrapper.ps1' as it triggers the actual user power script file. But when user missed to include this file, no appropriate error message is displayed to user which makes it difficult to find the root cause of his power shell script failing to execute. Hence, showing proper error message will solve this problem.
## What changed? 
Added error messages for missing config.json and StartingScriptWrapper.ps1
## How was the change tested?
Manually tested in local by making sure popup messages are properly displayed to users when the above files are missing.