### PR TITLE
New Provider ID for traceFixup

### DIFF
--- a/PsfShimMonitor/MainWindow.xaml.cs
+++ b/PsfShimMonitor/MainWindow.xaml.cs
@@ -47,7 +47,7 @@ namespace PsfMonitor
         // NOTE: The provider name and GUID must be kept in sync with PsfTrace/main.cpp
         //       The format of the provider name uses dashes here and dots in C++.
         //public Provider etwprovider = new Provider("Microsoft-Windows-PSFTrace",  new Guid(0x61F777A1, 0x1E59, 0x4BFC, 0xA6, 0x1A, 0xEF, 0x19, 0xC7, 0x16, 0xDD, 0xC0));
-        public Provider etwprovider = new Provider("Microsoft-Windows-PSFRuntime",  new Guid(0xf7f4e8c4, 0x9981, 0x5221, 0xe6, 0xfb, 0xff, 0x9d, 0xd1, 0xcd, 0xa4, 0xe1));
+        public Provider etwprovider = new Provider("Microsoft-Windows-PSFTraceFixup", new Guid(0x7c1d7c1c, 0x544b, 0x5179, 0x28, 0x01, 0x39, 0x29, 0xf0, 0x01, 0x78, 0x02));
         public int EventCounter = 1;
         public bool EventTraceProviderEnablementResultCode, EventTraceProviderSourceResultCode;
         public int LastSearchIndex = -1;

--- a/tests/fixups/TraceFixup/Logging.h
+++ b/tests/fixups/TraceFixup/Logging.h
@@ -348,6 +348,7 @@ inline std::string InterpretReturn(function_result functionResult, DWORD resultc
     results += "\n(";
     results += InterpretFrom_win32(resultcode);
     results += ")";
+    results += "-" + std::to_string(resultcode);
     return results;
 }
 
@@ -358,6 +359,7 @@ inline std::string InterpretReturn(function_result functionResult, BOOL bresultc
     results += "\n(";	
     results += bresultcode ? "Success" : InterpretFrom_win32(GetLastError());
     results += ")";
+    results += "-" + std::to_string(bresultcode);
     return results;
 }
 
@@ -375,6 +377,7 @@ inline std::string InterpretReturn(function_result functionResult, HRESULT hr)
         results += InterpretFrom_win32(HRESULT_CODE(hr));
     }
     results += ")";
+    results += "-" + std::to_string(hr);
     return results;
 }
 
@@ -392,6 +395,7 @@ inline std::string InterpretReturn(function_result functionResult, HANDLE hand)
         results += InterpretFrom_win32(GetLastError());
     }
     results += ")";
+    results += "-" + std::to_string(GetLastError());
     return results;
 }
 


### PR DESCRIPTION
## Why is this change being made?
Telemetry and TraceFixup/PSFMonitor uses same provider GUID which is not required.
Also, TraceFixup does not capture calling process. It only captures calling module.

## What changed?
New provider GUID is used for PSFShimMonitor/Trace Fixup
Calling process is also captured now through trace fixup

## How was the change tested?
Manually tested on MSIX applications to ensure new provider GUID works and ensuring Calling process is captured now.