### PR TITLE
User/mg/deletion marker/fixup initialize

### DIFF
--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -130,7 +130,7 @@ void InitializeConfiguration()
 {
     std::wstringstream traceDataStream;
     Log("RegLegacyFixups Start InitializeConfiguration()\n");
-    
+    MessageBoxExW(NULL, L"Config", L"InitializeFixup", 0, 0);
     if (auto rootConfig = ::PSFQueryCurrentDllConfig())
     {
         if (rootConfig != NULL)
@@ -282,26 +282,20 @@ void InitializeConfiguration()
                             }
                             Log("RegLegacyFixups:      have hive\n");
 
-                            // Look for Key - data
-                            traceDataStream << " key:\n";
-                            for (auto& key : regItemObject.get("key").as_array())
-                            {
-                                auto keyString = key.as_string().wstring();
-                                traceDataStream << keyString << " ;";
-                                Log(L"key:        %Ls\n", keyString.data());
-                                recordItem.deletionMarker.key.push_back(keyString.data());
-                            }
+                            // Look for key - data
+                            auto keyString = regItemObject.get("key").as_string().wstring();
+                            traceDataStream << keyString << " ;";
+                            Log(L"key:        %Ls\n", keyString.data());
+                            recordItem.deletionMarker.key.push_back(keyString.data());
+                            
                             Log("RegLegacyFixups:      have key\n");
 
-                            // Look for Value - data
-                            traceDataStream << " value:\n";
-                            for (auto& value : regItemObject.get("value").as_array())
-                            {
-                                auto valueString = value.as_string().wstring();
-                                traceDataStream << valueString << " ;";
-                                Log(L"value:        %Ls\n", valueString.data());
-                                recordItem.deletionMarker.value.push_back(valueString.data());
-                            }
+                            // Look for value - data
+                            auto valueString = regItemObject.get("value").as_string().wstring();
+                            traceDataStream << valueString << " ;";
+                            Log(L"value:        %Ls\n", valueString.data());
+                            recordItem.deletionMarker.value.push_back(valueString.data());
+
                             Log("RegLegacyFixups:      have value\n");
 
                             specItem.remediationRecords.push_back(recordItem);

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -268,11 +268,11 @@ void InitializeConfiguration()
                             traceDataStream << " hive: " << hiveType << " ;";
                             Log(L"Hive:      %Ls\n", hiveType.data());
 
-                            if (hiveType.compare(L"HKCU") == 0 || hiveType.compare(L"HKEY_CURRENT_USER") == 0)
+                            if (hiveType.compare(L"HKCU") == 0)
                             {
                                 recordItem.deletionMarker.hive = Modify_Key_Hive_Type_HKCU;
                             }
-                            else if (hiveType.compare(L"HKLM") == 0 || hiveType.compare(L"HKEY_LOCAL_MACHINE") == 0)
+                            else if (hiveType.compare(L"HKLM") == 0)
                             {
                                 recordItem.deletionMarker.hive = Modify_Key_Hive_Type_HKLM;
                             }

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -130,7 +130,6 @@ void InitializeConfiguration()
 {
     std::wstringstream traceDataStream;
     Log("RegLegacyFixups Start InitializeConfiguration()\n");
-    MessageBoxExW(NULL, L"Config", L"InitializeFixup", 0, 0);
     if (auto rootConfig = ::PSFQueryCurrentDllConfig())
     {
         if (rootConfig != NULL)

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -295,11 +295,11 @@ void InitializeConfiguration()
 
                             // Look for Value - data
                             traceDataStream << " value:\n";
-                            for (auto& value : regItemObject.get("key").as_array())
+                            for (auto& value : regItemObject.get("value").as_array())
                             {
                                 auto valueString = value.as_string().wstring();
                                 traceDataStream << valueString << " ;";
-                                Log(L"key:        %Ls\n", valueString.data());
+                                Log(L"value:        %Ls\n", valueString.data());
                                 recordItem.deletionMarker.value.push_back(valueString.data());
                             }
                             Log("RegLegacyFixups:      have value\n");

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -256,6 +256,56 @@ void InitializeConfiguration()
 
                             specItem.remediationRecords.push_back(recordItem);
                         }
+
+                        // Look for DeletionMarker remediation
+                        else if (type.compare(L"DeletionMarker") == 0)
+                        {
+                            Log("RegLegacyFixups:      is DeletionMarker\n");
+                            recordItem.remeditaionType = Reg_Remediation_type_DeletionMarker;
+
+                            // Look for hive - data
+                            auto hiveType = regItemObject.try_get("hive")->as_string().wstring();
+                            traceDataStream << " hive: " << hiveType << " ;";
+                            Log(L"Hive:      %Ls\n", hiveType.data());
+
+                            if (hiveType.compare(L"HKCU") == 0 || hiveType.compare(L"HKEY_CURRENT_USER") == 0)
+                            {
+                                recordItem.deletionMarker.hive = Modify_Key_Hive_Type_HKCU;
+                            }
+                            else if (hiveType.compare(L"HKLM") == 0 || hiveType.compare(L"HKEY_LOCAL_MACHINE") == 0)
+                            {
+                                recordItem.deletionMarker.hive = Modify_Key_Hive_Type_HKLM;
+                            }
+                            else
+                            {
+                                recordItem.deletionMarker.hive = Modify_Key_Hive_Type_Unknown;
+                            }
+                            Log("RegLegacyFixups:      have hive\n");
+
+                            // Look for Key - data
+                            traceDataStream << " key:\n";
+                            for (auto& key : regItemObject.get("key").as_array())
+                            {
+                                auto keyString = key.as_string().wstring();
+                                traceDataStream << keyString << " ;";
+                                Log(L"key:        %Ls\n", keyString.data());
+                                recordItem.deletionMarker.key.push_back(keyString.data());
+                            }
+                            Log("RegLegacyFixups:      have key\n");
+
+                            // Look for Value - data
+                            traceDataStream << " value:\n";
+                            for (auto& value : regItemObject.get("key").as_array())
+                            {
+                                auto valueString = value.as_string().wstring();
+                                traceDataStream << valueString << " ;";
+                                Log(L"key:        %Ls\n", valueString.data());
+                                recordItem.deletionMarker.value.push_back(valueString.data());
+                            }
+                            Log("RegLegacyFixups:      have value\n");
+
+                            specItem.remediationRecords.push_back(recordItem);
+                        }
                         else
                         {
                         }

--- a/fixups/RegLegacyFixups/Reg_Remediation_Spec.h
+++ b/fixups/RegLegacyFixups/Reg_Remediation_Spec.h
@@ -14,7 +14,8 @@ enum  Reg_Remediation_Types
 {
     Reg_Remediation_Type_Unknown = 0,
     Reg_Remediation_Type_ModifyKeyAccess,
-    Reg_Remediation_type_FakeDelete
+    Reg_Remediation_type_FakeDelete,
+    Reg_Remediation_type_DeletionMarker
 };
 
 enum Modify_Key_Access_Types
@@ -47,11 +48,19 @@ struct Fake_Delete_Key
     std::vector<std::wstring> patterns;
 };
 
+struct Deletion_Marker
+{
+    Modify_Key_Hive_Types hive;
+    std::vector<std::wstring> key;
+    std::vector<std::wstring> value;
+};
+
 struct Reg_Remediation_Record
 {
     Reg_Remediation_Types remeditaionType;
     Modify_Key_Access modifyKeyAccess;
     Fake_Delete_Key fakeDeleteKey;
+    Deletion_Marker deletionMarker;
 };
 
 struct Reg_Remediation_Spec

--- a/fixups/RegLegacyFixups/Reg_Remediation_Spec.h
+++ b/fixups/RegLegacyFixups/Reg_Remediation_Spec.h
@@ -32,7 +32,7 @@ enum Modify_Key_Hive_Types
 {
     Modify_Key_Hive_Type_Unknown = 0,
     Modify_Key_Hive_Type_HKCU = 1,
-    Modify_Key_Hive_Type_HKLM = 2,
+    Modify_Key_Hive_Type_HKLM = 2
 };
 
 struct Modify_Key_Access

--- a/tests/scenarios/RegLegacyTest/config.json
+++ b/tests/scenarios/RegLegacyTest/config.json
@@ -22,6 +22,18 @@
             {
               "remediation": [
                 {
+                  "type": "DeletionMarker",
+                  "hive": "HKLM",
+                  "key": "^TestKey",
+                  "value": "^TestValue"
+                },
+                {
+                  "type": "DeletionMarker",
+                  "hive": "HKCU",
+                  "key": "^TestKey",
+                  "value": "^TestValue"
+                },
+                {
                   "type": "ModifyKeyAccess",
                   "hive": "HKCU",
                   "patterns": [


### PR DESCRIPTION
## What changed?

- InitializeConfiguration - added deletion marker fixup initialization
- Reg_Remediation_Spec - modified/ added structures for deletion marker
- RegLegacyTest - config.json  - added remediation for deletion marker

## Why this change was required?

This change is required to achieve deletion marker fixup with PSF.

## How this change has been tested?

Manually tested. All existing tests are working fine. Summary : 0 tests failing.