### PR TITLE
BugFix | ReplaceRegistrySyntax

### DIFF
--- a/fixups/RegLegacyFixups/RegistryFixups.cpp
+++ b/fixups/RegLegacyFixups/RegistryFixups.cpp
@@ -52,7 +52,7 @@ std::string ReplaceRegistrySyntax(std::string regPath)
             }
             else
             {
-                returnPath = InterpretStringA("HKEY_LOCAL_MACHINE") + regPath.substr(18);
+                returnPath = InterpretStringA("HKEY_CURRENT_USER") + regPath.substr(18);
             }
         }
         else

--- a/fixups/RegLegacyFixups/RegistryFixups.cpp
+++ b/fixups/RegLegacyFixups/RegistryFixups.cpp
@@ -48,11 +48,11 @@ std::string ReplaceRegistrySyntax(std::string regPath)
             size_t offsetAfterSid = regPath.find('\\', 19);
             if (offsetAfterSid != std::string::npos)
             {
-                returnPath = InterpretStringA("HKEY_CURRENT_USER") + regPath.substr(offsetAfterSid);
+                returnPath = InterpretStringA("HKEY_LOCAL_MACHINE") + regPath.substr(offsetAfterSid);
             }
             else
             {
-                returnPath = InterpretStringA("HKEY_CURRENT_USER") + regPath.substr(18);
+                returnPath = InterpretStringA("HKEY_LOCAL_MACHINE") + regPath.substr(18);
             }
         }
         else


### PR DESCRIPTION
## Why this change?
Its a bug to return HKCU when registry path is HKLM in any case.

## What changed?
Return path with HKLM in method ReplaceRegistrySyntax.

## Tested?
Running all tests locally, with Overall Result: SUCCEEDED!