### PR TITLE
Deletion Marker Fixup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,3 +292,4 @@ __pycache__/
 
 # Visual Studio Code configuration/settings
 .vscode/
+/tests/scenarios/Appx

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -285,7 +285,7 @@ void InitializeConfiguration()
                             auto keyString = regItemObject.get("key").as_string().wstring();
                             traceDataStream << keyString << " ;";
                             Log(L"key:        %Ls\n", keyString.data());
-                            recordItem.deletionMarker.key.push_back(keyString.data());
+                            recordItem.deletionMarker.key = keyString.data();
                             
                             Log("RegLegacyFixups:      have key\n");
 
@@ -293,7 +293,7 @@ void InitializeConfiguration()
                             auto valueString = regItemObject.get("value").as_string().wstring();
                             traceDataStream << valueString << " ;";
                             Log(L"value:        %Ls\n", valueString.data());
-                            recordItem.deletionMarker.value.push_back(valueString.data());
+                            recordItem.deletionMarker.value = valueString.data();
 
                             Log("RegLegacyFixups:      have value\n");
 

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -130,7 +130,7 @@ void InitializeConfiguration()
 {
     std::wstringstream traceDataStream;
     Log("RegLegacyFixups Start InitializeConfiguration()\n");
-    
+    MessageBoxExW(NULL, L"Config", L"InitializeFixup", 0, 0);
     if (auto rootConfig = ::PSFQueryCurrentDllConfig())
     {
         if (rootConfig != NULL)
@@ -282,26 +282,20 @@ void InitializeConfiguration()
                             }
                             Log("RegLegacyFixups:      have hive\n");
 
-                            // Look for Key - data
-                            traceDataStream << " key:\n";
-                            for (auto& key : regItemObject.get("key").as_array())
-                            {
-                                auto keyString = key.as_string().wstring();
-                                traceDataStream << keyString << " ;";
-                                Log(L"key:        %Ls\n", keyString.data());
-                                recordItem.deletionMarker.key.push_back(keyString.data());
-                            }
+                            // Look for key - data
+                            auto keyString = regItemObject.get("key").as_string().wstring();
+                            traceDataStream << keyString << " ;";
+                            Log(L"key:        %Ls\n", keyString.data());
+                            recordItem.deletionMarker.key.push_back(keyString.data());
+                            
                             Log("RegLegacyFixups:      have key\n");
 
-                            // Look for Value - data
-                            traceDataStream << " value:\n";
-                            for (auto& value : regItemObject.get("value").as_array())
-                            {
-                                auto valueString = value.as_string().wstring();
-                                traceDataStream << valueString << " ;";
-                                Log(L"value:        %Ls\n", valueString.data());
-                                recordItem.deletionMarker.value.push_back(valueString.data());
-                            }
+                            // Look for value - data
+                            auto valueString = regItemObject.get("value").as_string().wstring();
+                            traceDataStream << valueString << " ;";
+                            Log(L"value:        %Ls\n", valueString.data());
+                            recordItem.deletionMarker.value.push_back(valueString.data());
+
                             Log("RegLegacyFixups:      have value\n");
 
                             specItem.remediationRecords.push_back(recordItem);

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -268,11 +268,11 @@ void InitializeConfiguration()
                             traceDataStream << " hive: " << hiveType << " ;";
                             Log(L"Hive:      %Ls\n", hiveType.data());
 
-                            if (hiveType.compare(L"HKCU") == 0 || hiveType.compare(L"HKEY_CURRENT_USER") == 0)
+                            if (hiveType.compare(L"HKCU") == 0)
                             {
                                 recordItem.deletionMarker.hive = Modify_Key_Hive_Type_HKCU;
                             }
-                            else if (hiveType.compare(L"HKLM") == 0 || hiveType.compare(L"HKEY_LOCAL_MACHINE") == 0)
+                            else if (hiveType.compare(L"HKLM") == 0)
                             {
                                 recordItem.deletionMarker.hive = Modify_Key_Hive_Type_HKLM;
                             }

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -130,7 +130,6 @@ void InitializeConfiguration()
 {
     std::wstringstream traceDataStream;
     Log("RegLegacyFixups Start InitializeConfiguration()\n");
-    MessageBoxExW(NULL, L"Config", L"InitializeFixup", 0, 0);
     if (auto rootConfig = ::PSFQueryCurrentDllConfig())
     {
         if (rootConfig != NULL)

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -291,16 +291,25 @@ void InitializeConfiguration()
 
                             // Look for value - data
                             traceDataStream << " values:\n";
-                            for (auto& value : regItemObject.get("values").as_array())
+
+                            auto values = regItemObject.try_get("values");
+                            if (values != nullptr)
                             {
-                                auto valueString = value.as_string().wstring();
-                                traceDataStream << valueString << " ;";
-                                Log(L"Value:        %Ls\n", valueString.data());
-                                recordItem.deletionMarker.values.push_back(valueString.data());
+                                for (auto& value : values->as_array())
+                                {
+                                    auto valueString = value.as_string().wstring();
+                                    traceDataStream << valueString << " ;";
+                                    Log(L"Value:        %Ls\n", valueString.data());
+                                    recordItem.deletionMarker.values.push_back(valueString.data());
+                                }
+
+                                Log("RegLegacyFixups:      have value\n");
                             }
-
-                            Log("RegLegacyFixups:      have value\n");
-
+                            else
+                            {
+                                Log("RegLegacyFixups:      have no value\n");
+                            }
+                            
                             specItem.remediationRecords.push_back(recordItem);
                         }
                         else

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -290,10 +290,14 @@ void InitializeConfiguration()
                             Log("RegLegacyFixups:      have key\n");
 
                             // Look for value - data
-                            auto valueString = regItemObject.get("value").as_string().wstring();
-                            traceDataStream << valueString << " ;";
-                            Log(L"value:        %Ls\n", valueString.data());
-                            recordItem.deletionMarker.value = valueString.data();
+                            traceDataStream << " values:\n";
+                            for (auto& value : regItemObject.get("values").as_array())
+                            {
+                                auto valueString = value.as_string().wstring();
+                                traceDataStream << valueString << " ;";
+                                Log(L"Value:        %Ls\n", valueString.data());
+                                recordItem.deletionMarker.values.push_back(valueString.data());
+                            }
 
                             Log("RegLegacyFixups:      have value\n");
 

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -295,11 +295,11 @@ void InitializeConfiguration()
 
                             // Look for Value - data
                             traceDataStream << " value:\n";
-                            for (auto& value : regItemObject.get("key").as_array())
+                            for (auto& value : regItemObject.get("value").as_array())
                             {
                                 auto valueString = value.as_string().wstring();
                                 traceDataStream << valueString << " ;";
-                                Log(L"key:        %Ls\n", valueString.data());
+                                Log(L"value:        %Ls\n", valueString.data());
                                 recordItem.deletionMarker.value.push_back(valueString.data());
                             }
                             Log("RegLegacyFixups:      have value\n");

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -256,6 +256,56 @@ void InitializeConfiguration()
 
                             specItem.remediationRecords.push_back(recordItem);
                         }
+
+                        // Look for DeletionMarker remediation
+                        else if (type.compare(L"DeletionMarker") == 0)
+                        {
+                            Log("RegLegacyFixups:      is DeletionMarker\n");
+                            recordItem.remeditaionType = Reg_Remediation_type_DeletionMarker;
+
+                            // Look for hive - data
+                            auto hiveType = regItemObject.try_get("hive")->as_string().wstring();
+                            traceDataStream << " hive: " << hiveType << " ;";
+                            Log(L"Hive:      %Ls\n", hiveType.data());
+
+                            if (hiveType.compare(L"HKCU") == 0 || hiveType.compare(L"HKEY_CURRENT_USER") == 0)
+                            {
+                                recordItem.deletionMarker.hive = Modify_Key_Hive_Type_HKCU;
+                            }
+                            else if (hiveType.compare(L"HKLM") == 0 || hiveType.compare(L"HKEY_LOCAL_MACHINE") == 0)
+                            {
+                                recordItem.deletionMarker.hive = Modify_Key_Hive_Type_HKLM;
+                            }
+                            else
+                            {
+                                recordItem.deletionMarker.hive = Modify_Key_Hive_Type_Unknown;
+                            }
+                            Log("RegLegacyFixups:      have hive\n");
+
+                            // Look for Key - data
+                            traceDataStream << " key:\n";
+                            for (auto& key : regItemObject.get("key").as_array())
+                            {
+                                auto keyString = key.as_string().wstring();
+                                traceDataStream << keyString << " ;";
+                                Log(L"key:        %Ls\n", keyString.data());
+                                recordItem.deletionMarker.key.push_back(keyString.data());
+                            }
+                            Log("RegLegacyFixups:      have key\n");
+
+                            // Look for Value - data
+                            traceDataStream << " value:\n";
+                            for (auto& value : regItemObject.get("key").as_array())
+                            {
+                                auto valueString = value.as_string().wstring();
+                                traceDataStream << valueString << " ;";
+                                Log(L"key:        %Ls\n", valueString.data());
+                                recordItem.deletionMarker.value.push_back(valueString.data());
+                            }
+                            Log("RegLegacyFixups:      have value\n");
+
+                            specItem.remediationRecords.push_back(recordItem);
+                        }
                         else
                         {
                         }

--- a/fixups/RegLegacyFixups/Reg_Remediation_Spec.h
+++ b/fixups/RegLegacyFixups/Reg_Remediation_Spec.h
@@ -14,7 +14,8 @@ enum  Reg_Remediation_Types
 {
     Reg_Remediation_Type_Unknown = 0,
     Reg_Remediation_Type_ModifyKeyAccess,
-    Reg_Remediation_type_FakeDelete
+    Reg_Remediation_type_FakeDelete,
+    Reg_Remediation_type_DeletionMarker
 };
 
 enum Modify_Key_Access_Types
@@ -47,11 +48,19 @@ struct Fake_Delete_Key
     std::vector<std::wstring> patterns;
 };
 
+struct Deletion_Marker
+{
+    Modify_Key_Hive_Types hive;
+    std::vector<std::wstring> key;
+    std::vector<std::wstring> value;
+};
+
 struct Reg_Remediation_Record
 {
     Reg_Remediation_Types remeditaionType;
     Modify_Key_Access modifyKeyAccess;
     Fake_Delete_Key fakeDeleteKey;
+    Deletion_Marker deletionMarker;
 };
 
 struct Reg_Remediation_Spec

--- a/fixups/RegLegacyFixups/Reg_Remediation_Spec.h
+++ b/fixups/RegLegacyFixups/Reg_Remediation_Spec.h
@@ -32,7 +32,7 @@ enum Modify_Key_Hive_Types
 {
     Modify_Key_Hive_Type_Unknown = 0,
     Modify_Key_Hive_Type_HKCU = 1,
-    Modify_Key_Hive_Type_HKLM = 2,
+    Modify_Key_Hive_Type_HKLM = 2
 };
 
 struct Modify_Key_Access

--- a/fixups/RegLegacyFixups/Reg_Remediation_Spec.h
+++ b/fixups/RegLegacyFixups/Reg_Remediation_Spec.h
@@ -52,7 +52,7 @@ struct Deletion_Marker
 {
     Modify_Key_Hive_Types hive;
     std::wstring key;
-    std::wstring value;
+    std::vector<std::wstring> values;
 };
 
 struct Reg_Remediation_Record

--- a/fixups/RegLegacyFixups/Reg_Remediation_Spec.h
+++ b/fixups/RegLegacyFixups/Reg_Remediation_Spec.h
@@ -51,8 +51,8 @@ struct Fake_Delete_Key
 struct Deletion_Marker
 {
     Modify_Key_Hive_Types hive;
-    std::vector<std::wstring> key;
-    std::vector<std::wstring> value;
+    std::wstring key;
+    std::wstring value;
 };
 
 struct Reg_Remediation_Record

--- a/fixups/RegLegacyFixups/RegistryFixups.cpp
+++ b/fixups/RegLegacyFixups/RegistryFixups.cpp
@@ -48,7 +48,7 @@ std::string ReplaceRegistrySyntax(std::string regPath)
             size_t offsetAfterSid = regPath.find('\\', 19);
             if (offsetAfterSid != std::string::npos)
             {
-                returnPath = InterpretStringA("HKEY_LOCAL_MACHINE") + regPath.substr(offsetAfterSid);
+                returnPath = InterpretStringA("HKEY_CURRENT_USER") + regPath.substr(offsetAfterSid);
             }
             else
             {

--- a/fixups/RegLegacyFixups/RegistryFixups.cpp
+++ b/fixups/RegLegacyFixups/RegistryFixups.cpp
@@ -720,6 +720,7 @@ LSTATUS __stdcall  RegGetValueFixup(
 )
 {
     // To Do : Add Logic for deletion marker
+    return RegGetValueImpl(hkey, lpSubKey, lpValue, dwFlags, pdwType, pvData, pcbData);
 }
 DECLARE_STRING_FIXUP(RegGetValueImpl, RegGetValueFixup);
 
@@ -739,6 +740,7 @@ LSTATUS __stdcall RegQueryMultipleValuesFixup(
 )
 {
     // To Do : Add Logic for deletion marker
+    return RegQueryMultipleValuesImpl(hKey, val_list, num_vals, lpValueBuf, ldwTotsize);
 
 }
 DECLARE_STRING_FIXUP(RegQueryMultipleValuesImpl, RegQueryMultipleValuesFixup);

--- a/fixups/RegLegacyFixups/RegistryFixups.cpp
+++ b/fixups/RegLegacyFixups/RegistryFixups.cpp
@@ -725,14 +725,15 @@ LSTATUS __stdcall RegEnumValueFixup(
     {
 #ifdef _DEBUG
         Log("[%d] RegEnumValue:\n", RegLocalInstance);
-
 #endif
         DWORD Index = 0;
         DWORD CountDeletionMarkerValues = 0;
         
         do
         {
-            response = RegEnumValueImpl(hKey, Index, lpValueName, lpcchValueName, lpReserved, lpType, lpData, lpcbData);
+            CharT ValueName[INT16_MAX];
+            DWORD lpdValueName = INT16_MAX;
+            response = RegEnumValueImpl(hKey, Index, ValueName, &lpdValueName, nullptr, nullptr, nullptr, nullptr);
             
             if (response == ERROR_SUCCESS)
             {
@@ -741,7 +742,7 @@ LSTATUS __stdcall RegEnumValueFixup(
                 keyPath = InterpretRegistryPath(keyPath);
 #ifdef _DEBUG
                 Log("[%d] RegEnumValue: path=%s", RegLocalInstance, keyPath.c_str());
-                if (RegFixupDeletionMarker(keyPath, lpValueName, RegLocalInstance) == true)
+                if (RegFixupDeletionMarker(keyPath, ValueName, RegLocalInstance) == true)
 #else
                 if (RegFixupDeletionMarker(keyPath, lpValueName) == true)
 #endif
@@ -757,7 +758,7 @@ LSTATUS __stdcall RegEnumValueFixup(
 #ifdef _DEBUG
                     Log("[%d] RegEnumValue:Index Found\n", RegLocalInstance);
 #endif 
-                    return response;
+                    return RegEnumValueImpl(hKey, Index, lpValueName, lpcchValueName, lpReserved, lpType, lpData, lpcbData);
                 }
             }
             else

--- a/fixups/RegLegacyFixups/RegistryFixups.cpp
+++ b/fixups/RegLegacyFixups/RegistryFixups.cpp
@@ -519,6 +519,7 @@ LSTATUS __stdcall RegOpenKeyTransactedFixup(
 DECLARE_STRING_FIXUP(RegOpenKeyTransactedImpl, RegOpenKeyTransactedFixup);
 
 
+
 /// <summary>
 /// Method to check if given keyValue is a deletion-marker
 /// </summary>
@@ -526,7 +527,6 @@ DECLARE_STRING_FIXUP(RegOpenKeyTransactedImpl, RegOpenKeyTransactedFixup);
 /// <param name="keyValue"></param>
 /// <param name="RegLocalInstance"></param>
 /// <returns></returns>
-
 
 template <typename CharT>
 #ifdef _DEBUG
@@ -579,8 +579,8 @@ bool RegFixupDeletionMarker(std::string keyPath, std::string keyValue)
                                 if (std::regex_match(widen(keyValue), std::wregex(specitem.deletionMarker.value)))
                                 {
 #ifdef _DEBUG
-                                    Log("[%d] RegFixupDeletionMarker: is HKCU key value match.\n", RegLocalInstance);
-                                    Log("[%d] RegFixupDeletionMarker: is HKCU key value match.\n", RegLocalInstance);
+                                    Log("[%d] RegFixupDeletionMarker: is HKCU key-value match.\n", RegLocalInstance);
+                                    Log("[%d] RegFixupDeletionMarker: Deletion-Marker true.\n", RegLocalInstance);
 #endif
                                     isKeyDeletionMarker = true;
                                 }
@@ -614,8 +614,8 @@ bool RegFixupDeletionMarker(std::string keyPath, std::string keyValue)
                                 if (std::regex_match(widen(keyValue), std::wregex(specitem.deletionMarker.value)))
                                 {
 #ifdef _DEBUG
-                                    Log("[%d] RegFixupDeletionMarker: is HKLM key value match.\n", RegLocalInstance);
-                                    Log("[%d] RegFixupDeletionMarker: is HKLM key value match.\n", RegLocalInstance);
+                                    Log("[%d] RegFixupDeletionMarker: is HKLM key-value match.\n", RegLocalInstance);
+                                    Log("[%d] RegFixupDeletionMarker: Deletion-Marker true.\n", RegLocalInstance);
 #endif
                                     isKeyDeletionMarker = true;
                                 }
@@ -623,7 +623,7 @@ bool RegFixupDeletionMarker(std::string keyPath, std::string keyValue)
                         }
                         catch (...)
                         {
-                            psf::TraceLogExceptions("RegLegacyFixupException", "Bad Regex pattern ignored in RegLegacyFixups. Hive: HKCU");
+                            psf::TraceLogExceptions("RegLegacyFixupException", "Bad Regex pattern ignored in RegLegacyFixups. Hive: HKLM");
                             Log("[%d] Bad Regex pattern ignored in RegLegacyFixups.\n", RegLocalInstance);
                         }
                     }
@@ -631,7 +631,7 @@ bool RegFixupDeletionMarker(std::string keyPath, std::string keyValue)
                 default:
                     break;
                 }
-
+            default:
                 break;
             }
         }

--- a/fixups/RegLegacyFixups/RegistryFixups.cpp
+++ b/fixups/RegLegacyFixups/RegistryFixups.cpp
@@ -1034,9 +1034,9 @@ LSTATUS __stdcall RegQueryInfoKeyFixup(
                 else if (response == ERROR_NO_MORE_ITEMS)
                 {
                     // Update lpcValues, lpcbMaxValueNameLen, lpcbMaxValueLen
-                    lpcValues = &CountValues;
-                    lpcbMaxValueNameLen = &dValueName;
-                    lpcbMaxValueLen = &dData;
+                    *lpcValues = CountValues;
+                    *lpcbMaxValueNameLen = MaxValueNameLen;
+                    *lpcbMaxValueLen = MaxDataLen;
 #if _DEBUG
                     Log("[%d] RegQueryInfoKey: lpcValues=  %d, lpcbMaxValueNameLen= %d, lpcbMaxValueLen= %d\n", RegLocalInstance, CountValues, dValueName, dData);
 #endif
@@ -1085,27 +1085,17 @@ LSTATUS __stdcall RegQueryInfoKeyFixup(
                 if (response == ERROR_SUCCESS)
                 {
                     CountSubKeys++;
-
-                    //Remove size of null character from MaxSubKeyLen
-                    if constexpr (psf::is_ansi<CharT>)
-                    {
-                        NameLen = NameLen - sizeof(CHAR);
-                    }
-                    else
-                    {
-                        NameLen = NameLen - sizeof(WCHAR);
-                    }
-
                     MaxSubKeyLen = max(MaxSubKeyLen, NameLen);
                 }
                 else if (response == ERROR_NO_MORE_ITEMS)
                 {
                     // Update lpcSubKeys & lpcbMaxSubKeyLen
-                    lpcSubKeys = &CountSubKeys;
-                    lpcbMaxSubKeyLen = &MaxSubKeyLen;
+                    *lpcSubKeys = CountSubKeys;
+                    *lpcbMaxSubKeyLen = MaxSubKeyLen;
 #if _DEBUG
                     Log("[%d] RegQueryInfoKey: lpcSubKeys=  %d, lpcbMaxSubKeyLen= %d\n", RegLocalInstance, CountSubKeys, MaxSubKeyLen);
 #endif
+                    break;
                 }
                 else
                 {

--- a/fixups/RegLegacyFixups/RegistryFixups.cpp
+++ b/fixups/RegLegacyFixups/RegistryFixups.cpp
@@ -394,13 +394,17 @@ bool RegFixupDeletionMarker(std::string keyPath, const CharT* keyValue)
 #ifdef _DEBUG
                                 Log("[%d] RegFixupDeletionMarker: is HKCU key match.\n", RegLocalInstance);
 #endif
-                                if (specitem.deletionMarker.values.empty() || keyValue == NULL)
+                                if (specitem.deletionMarker.values.empty())
                                 {
                                     // Deletion Marker for Key Found
 #ifdef _DEBUG
                                     Log("[%d] RegFixupDeletionMarker: No Values\n", RegLocalInstance);
 #endif
                                     return true;
+                                }
+                                else if (keyValue == NULL)
+                                {
+                                    return false;
                                 }
                                 else
                                 {
@@ -449,13 +453,17 @@ bool RegFixupDeletionMarker(std::string keyPath, const CharT* keyValue)
 #ifdef _DEBUG
                                 Log("[%d] RegFixupDeletionMarker: is HKLM key match.\n", RegLocalInstance);
 #endif
-                                if (specitem.deletionMarker.values.empty() || keyValue == NULL)
+                                if (specitem.deletionMarker.values.empty())
                                 {
                                     // Deletion Marker for Key Found
 #ifdef _DEBUG
                                     Log("[%d] RegFixupDeletionMarker: No Values\n", RegLocalInstance);
 #endif
                                     return true;
+                                }
+                                else if (keyValue == NULL)
+                                {
+                                    return false;
                                 }
                                 else
                                 {
@@ -881,9 +889,10 @@ LSTATUS __stdcall RegQueryInfoKeyFixup(
 {
     LARGE_INTEGER TickStart, TickEnd;
     QueryPerformanceCounter(&TickStart);
-    DWORD RegLocalInstance = ++g_RegIntceptInstance;
     auto entry = LogFunctionEntry();
-
+#if _DEBUG
+    DWORD RegLocalInstance = ++g_RegIntceptInstance;
+#endif
     auto result = RegQueryInfoKeyImpl(hKey, lpClass, lpcchClass, lpReserved, lpcSubKeys, lpcbMaxSubKeyLen, lpcbMaxClassLen, lpcValues, lpcbMaxValueNameLen, lpcbMaxValueLen, lpcbSecurityDescriptor, lpftLastWriteTime);
 
     if (result == ERROR_SUCCESS)

--- a/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
+++ b/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
@@ -113,6 +113,16 @@ namespace DeletionMarkerTest
 	}
 
 	/// <summary>
+	/// Test for RegQueryInfoKey
+	/// Deletion Marker Found
+	/// </summary>
+	/// <param name="result"></param>
+	inline void RegQueryInfoKey_SUCCESS(int result)
+	{
+		RegQueryInfoKey_SUCCESS_HKCU(result);
+	}
+
+	/// <summary>
 	/// Test for Deletion Marker Fixup
 	/// </summary>
 	/// <param name="result"></param>
@@ -137,5 +147,7 @@ namespace DeletionMarkerTest
 		RegOpenKeyTransacted_DeletionMarkerFound(result);
 
 		RegEnumKeyEx_DeletionMarkerFound(result);
+
+		RegQueryInfoKey_SUCCESS(result);
 	}
 }

--- a/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
+++ b/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
@@ -94,12 +94,22 @@ namespace DeletionMarkerTest
 
 	/// <summary>
 	/// Test for RegOpenKeyTransacted
-	/// DeletionMarkerFound
+	/// Deletion Marker Found
 	/// </summary>
 	/// <param name="result"></param>
 	inline void RegOpenKeyTransacted_DeletionMarkerFound(int result)
 	{
 		RegOpenKeyTransacted_FILENOTFOUND_HKLM(result);
+	}
+
+	/// <summary>
+	/// Test for RegEnumKeyEx
+	/// Deletion Marker Found
+	/// </summary>
+	/// <param name="result"></param>
+	inline void RegEnumKeyEx_DeletionMarkerFound(int result)
+	{
+		RegEnumKeyEx_FILENOTFOUND_HKLM(result);
 	}
 
 	/// <summary>
@@ -125,5 +135,7 @@ namespace DeletionMarkerTest
 		RegOpenKeyEx_DeletionMarkerFound(result);
 
 		RegOpenKeyTransacted_DeletionMarkerFound(result);
+
+		RegEnumKeyEx_DeletionMarkerFound(result);
 	}
 }

--- a/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
+++ b/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
@@ -73,6 +73,16 @@ namespace DeletionMarkerTest
 	}
 
 	/// <summary>
+	/// Test for RegEnumValue
+	/// Deletion Marker Found
+	/// </summary>
+	/// <param name="result"></param>
+	inline void RegEnumValue_DeletionMarkerFound(int result)
+	{
+		RegEnumValue_DeletionMarkerFound_HKLM(result);
+	}
+
+	/// <summary>
 	/// Test for Deletion Marker Fixup
 	/// </summary>
 	/// <param name="result"></param>
@@ -89,5 +99,7 @@ namespace DeletionMarkerTest
 		RegQueryMultipleValues_SUCCESS(result);
 
 		RegQueryMultipleValues_FILENOTFOUND(result);
+
+		RegEnumValue_DeletionMarkerFound(result);
 	}
 }

--- a/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
+++ b/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
@@ -33,6 +33,46 @@ namespace DeletionMarkerTest
 	}
 
 	/// <summary>
+	/// Test for RegGetValue
+	/// Deletion Marker NOT found
+	/// </summary>
+	/// <param name="result"></param>
+	inline void RegGetValue_SUCCESS(int result)
+	{
+		RegGetValue_SUCCESS_HKCU(result);
+	}
+
+	/// <summary>
+	/// Test for RegGetValue
+	/// Deletion Marker Found
+	/// </summary>
+	/// <param name="result"></param>
+	inline void RegGetValue_FILENOTFOUND(int result)
+	{
+		RegGetValue_FILENOTFOUND_HKLM(result);
+	}
+
+	/// <summary>
+	/// Test for RegQueryMultipleValues
+	/// Deletion Marker Not Found
+	/// </summary>
+	/// <param name="result"></param>
+	inline void RegQueryMultipleValues_SUCCESS(int result)
+	{
+		RegQueryMultipleValues_SUCCESS_HKCU(result);
+	}
+
+	/// <summary>
+	/// Test for RegQueryMultipleValues
+	/// Deletion Marker Found
+	/// </summary>
+	/// <param name="result"></param>
+	inline void RegQueryMultipleValues_FILENOTFOUND(int result)
+	{
+		RegQueryMultipleValues_FILENOTFOUND_HKLM(result);
+	}
+
+	/// <summary>
 	/// Test for Deletion Marker Fixup
 	/// </summary>
 	/// <param name="result"></param>
@@ -41,5 +81,13 @@ namespace DeletionMarkerTest
 		RegQueryValueEx_SUCCESS(result);
 
 		RegQueryValueEx_FILENOTFOUND(result);
+
+		RegGetValue_SUCCESS(result);
+
+		RegGetValue_FILENOTFOUND(result);
+
+		RegQueryMultipleValues_SUCCESS(result);
+
+		RegQueryMultipleValues_FILENOTFOUND(result);
 	}
 }

--- a/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
+++ b/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
@@ -1,0 +1,52 @@
+#pragma region Include
+#include "Helper.cpp"
+#pragma endregion
+
+#pragma region Using
+using namespace Helper;
+#pragma endregion
+
+namespace DeletionMarkerTest
+{
+	/// <summary>
+	/// Test for RegQueryValueExW
+	/// Deletion Marker Not Found
+	/// </summary>
+	/// <param name="result"></param>
+	inline void RegQueryValueEx_SUCCESS(int result)
+	{
+		//test_begin("RegLegacy Test DeletionMarkerTests SUCCESS HKCU");
+		RegQueryValueEx_SUCCESS_HKCU(result);
+
+		//test_begin("RegLegacy Test DeletionMarkerTests SUCCESS HKLM");
+		RegQueryValueEx_SUCCESS_HKLM(result);
+	}
+
+	/// <summary>
+	/// Test for RegQueryValueExW
+	/// Deletion Marker Found
+	/// </summary>
+	/// <param name="result"></param>
+	inline void RegQueryValueEx_FILENOTFOUND(int result)
+	{
+		//test_begin("RegLegacy Test DeletionMarkerTests FILE_NOT_FOUND HKCU");
+		RegQueryValueEx_FILENOTFOUND_HKCU(result);
+
+		//test_begin("RegLegacy Test DeletionMarkerTests FILE_NOT_FOUND HKLM");
+		RegQueryValueEx_FILENOTFOUND_HKLM(result);
+	}
+
+	/// <summary>
+	/// Test for Deletion Marker Fixup
+	/// </summary>
+	/// <param name="result"></param>
+	inline void DeletionMarkerTests(int result)
+	{
+		//test_begin("RegLegacy Test DeletionMarkerTests SUCCESS");
+		RegQueryValueEx_SUCCESS(result);
+
+
+		//test_begin("RegLegacy Test DeletionMarkerTests FILENOTFOUND");
+		RegQueryValueEx_FILENOTFOUND(result);
+	}
+}

--- a/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
+++ b/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
@@ -83,6 +83,16 @@ namespace DeletionMarkerTest
 	}
 
 	/// <summary>
+	/// Test for RegOpenKeyEx
+	/// Deletion Marker Found
+	/// </summary>
+	/// <param name="result"></param>
+	inline void RegOpenKeyEx_DeletionMarkerFound(int result)
+	{
+		RegOpenKeyEx_FILENOTFOUND_HKLM(result);
+	}
+
+	/// <summary>
 	/// Test for Deletion Marker Fixup
 	/// </summary>
 	/// <param name="result"></param>
@@ -101,5 +111,7 @@ namespace DeletionMarkerTest
 		RegQueryMultipleValues_FILENOTFOUND(result);
 
 		RegEnumValue_DeletionMarkerFound(result);
+
+		RegOpenKeyEx_DeletionMarkerFound(result);
 	}
 }

--- a/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
+++ b/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
@@ -93,6 +93,16 @@ namespace DeletionMarkerTest
 	}
 
 	/// <summary>
+	/// Test for RegOpenKeyTransacted
+	/// DeletionMarkerFound
+	/// </summary>
+	/// <param name="result"></param>
+	inline void RegOpenKeyTransacted_DeletionMarkerFound(int result)
+	{
+		RegOpenKeyTransacted_FILENOTFOUND_HKLM(result);
+	}
+
+	/// <summary>
 	/// Test for Deletion Marker Fixup
 	/// </summary>
 	/// <param name="result"></param>
@@ -113,5 +123,7 @@ namespace DeletionMarkerTest
 		RegEnumValue_DeletionMarkerFound(result);
 
 		RegOpenKeyEx_DeletionMarkerFound(result);
+
+		RegOpenKeyTransacted_DeletionMarkerFound(result);
 	}
 }

--- a/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
+++ b/tests/scenarios/RegLegacyTest/DeletionMarkerTest.cpp
@@ -15,10 +15,8 @@ namespace DeletionMarkerTest
 	/// <param name="result"></param>
 	inline void RegQueryValueEx_SUCCESS(int result)
 	{
-		//test_begin("RegLegacy Test DeletionMarkerTests SUCCESS HKCU");
 		RegQueryValueEx_SUCCESS_HKCU(result);
 
-		//test_begin("RegLegacy Test DeletionMarkerTests SUCCESS HKLM");
 		RegQueryValueEx_SUCCESS_HKLM(result);
 	}
 
@@ -29,10 +27,8 @@ namespace DeletionMarkerTest
 	/// <param name="result"></param>
 	inline void RegQueryValueEx_FILENOTFOUND(int result)
 	{
-		//test_begin("RegLegacy Test DeletionMarkerTests FILE_NOT_FOUND HKCU");
 		RegQueryValueEx_FILENOTFOUND_HKCU(result);
 
-		//test_begin("RegLegacy Test DeletionMarkerTests FILE_NOT_FOUND HKLM");
 		RegQueryValueEx_FILENOTFOUND_HKLM(result);
 	}
 
@@ -42,11 +38,8 @@ namespace DeletionMarkerTest
 	/// <param name="result"></param>
 	inline void DeletionMarkerTests(int result)
 	{
-		//test_begin("RegLegacy Test DeletionMarkerTests SUCCESS");
 		RegQueryValueEx_SUCCESS(result);
 
-
-		//test_begin("RegLegacy Test DeletionMarkerTests FILENOTFOUND");
 		RegQueryValueEx_FILENOTFOUND(result);
 	}
 }

--- a/tests/scenarios/RegLegacyTest/Helper.cpp
+++ b/tests/scenarios/RegLegacyTest/Helper.cpp
@@ -726,4 +726,70 @@ namespace Helper
         }
         test_end(result);
     }
+
+    /// <summary>
+    /// Test for RegQueryInfoKey
+    /// hive : HKCU
+    /// </summary>
+    /// <param name="result"></param>
+    void inline RegQueryInfoKey_SUCCESS_HKCU(int result)
+    {
+        test_begin("RegLegacy Test DeletionMarker - RegQueryInfoKey HKLM (SUCCESS)");
+
+        try
+        {
+            HKEY hkey;
+            if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TestKeyName_HKLM_SYSTEM, 0, KEY_ALL_ACCESS, &hkey) == ERROR_SUCCESS)
+            {
+                DWORD dwSubKeyCount = 0;
+                DWORD dwMaxSubKeyNameLen = 0;
+                DWORD dwValueCount = 0;
+                DWORD dwMaxValueNameLen = 0;
+                DWORD dwMaxValueLen = 0;
+
+                auto response = RegQueryInfoKeyW(hkey, NULL, NULL, NULL, &dwSubKeyCount, &dwMaxSubKeyNameLen, NULL, &dwValueCount, &dwMaxValueNameLen, &dwMaxValueLen, NULL, NULL);
+                MessageBoxExW(NULL, L"Test", L"", 0, 0);
+                if (response == ERROR_SUCCESS)
+                {
+                    trace_message("Query Key Success", console::color::gray, true);
+                    result = 0;
+                    if ((dwSubKeyCount || dwMaxSubKeyNameLen || dwValueCount || dwMaxValueNameLen || dwMaxValueLen) != 0)
+                    {
+                        trace_message("Data does not match");
+                        result = ERROR_CURRENT_DIRECTORY;
+                    }
+                    
+                    RegCloseKey(hkey);
+                }
+                else if (response == ERROR_MORE_DATA)
+                {
+                    trace_messages("Buffer is too small to receive the name of the class,");
+                    result = response;
+                }
+                else
+                {
+                    trace_message("Function Failed.", console::color::red, true);
+                    result = GetLastError();
+                    if (result == 0)
+                        result = ERROR_PATH_NOT_FOUND;
+                    print_last_error("Failed to find key");
+                }
+            }
+            else
+            {
+                trace_message("Failed to find key. Most likely a bug in the testing tool.", console::color::red, true);
+                result = GetLastError();
+                if (result == 0)
+                    result = ERROR_PATH_NOT_FOUND;
+                print_last_error("Failed to find key");
+            }
+        }
+        catch (...)
+        {
+            trace_message("Unexpected error.", console::color::red, true);
+            result = GetLastError();
+            print_last_error("Failed Deletion Marker HKLM case (SUCCESS)");
+        }
+        test_end(result);
+    }
 }

--- a/tests/scenarios/RegLegacyTest/Helper.cpp
+++ b/tests/scenarios/RegLegacyTest/Helper.cpp
@@ -1,0 +1,279 @@
+#pragma region Include
+#include <test_config.h>
+#include <appmodel.h>
+#include <algorithm>
+#include <filesystem>
+#pragma endregion
+
+#pragma region Using
+using namespace std::literals;
+#pragma endregion
+
+#pragma region Define
+// The folllowing strings must match with registry keys present in the appropriate section of the package Registry.dat file.
+#define TestKeyName_HKCU_Covered        L"Software\\Vendor_Covered"
+#define TestKeyName_HKCU_NotCovered     L"Software\\Vendor_NotCovered"
+
+#define TestKeyName_HKLM_Covered        L"SOFTWARE\\Vendor_Covered"        // Registry contains both regular and wow entries so this works.
+#define TestKeyName_HKLM_NotCovered     L"SOFTWARE\\Vendor_NotCovered"
+#define TestKeyName_Covered_SubKey      L"SOFTWARE\\Vendor_Covered\\SubKey"
+
+#define TestSubSubKey                   L"SubKey"
+#define TestSubItem                     L"SubItem"
+#define TestSubItem_FILENOTFOUND        L"DeletionMarker"
+#pragma endregion
+
+namespace Helper
+{
+    /// <summary>
+    /// Test for RegQueryValueExW
+    /// hive : HKCU
+    /// Deletion Marker Not Found
+    /// </summary>
+    /// <param name="result"></param>
+    inline void RegQueryValueEx_SUCCESS_HKCU(int result)
+    {
+        MessageBoxExW(NULL, L"inside DeletionMarkerTests", L"Tests", 0, 0);
+
+        test_begin("RegLegacy Test DeletionMarker HKCU (SUCCESS)");
+
+        try
+        {
+            HKEY hKey;
+
+            if (RegOpenKeyEx(HKEY_CURRENT_USER, TestKeyName_HKCU_Covered, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+            {
+                DWORD dwType;
+                TCHAR szData[256];
+                DWORD dwDataSize = sizeof(szData);
+
+                auto response = RegQueryValueExW(hKey, TestSubItem, NULL, &dwType, (LPBYTE)szData, &dwDataSize);
+
+                if (response == ERROR_SUCCESS)
+                {
+                    trace_message(szData, console::color::gray, true);
+                    trace_messages("HKCU Deletion Marker Not Found");
+                    result = 0;
+                }
+                else if (response == ERROR_FILE_NOT_FOUND)
+                {
+                    trace_messages("HKCU Deletion Marker Found");
+                    result = ERROR_FILE_NOT_FOUND;
+                }
+                else
+                {
+                    trace_message("Failed to find read subItem.", console::color::red, true);
+                    result = GetLastError();
+                    if (result == 0)
+                        result = ERROR_FILE_NOT_FOUND;
+                    print_last_error("Failed to find read subItem");
+                }
+                RegCloseKey(hKey);
+            }
+            else
+            {
+                trace_message("Failed to find key. Most likely a bug in the testing tool.", console::color::red, true);
+                result = GetLastError();
+                if (result == 0)
+                    result = ERROR_PATH_NOT_FOUND;
+                print_last_error("Failed to find key");
+            }
+        }
+        catch (...)
+        {
+            trace_message("Unexpected error.", console::color::red, true);
+            result = GetLastError();
+            print_last_error("Failed Deletion Marker HKCU case (SUCCESS)");
+        }
+        test_end(result);
+    }
+
+    /// <summary>
+    /// Test for RegQueryValueExW
+    /// hive : HKLM
+    /// Deletion Marker Not Found
+    /// </summary>
+    /// <param name="result"></param>
+    inline void RegQueryValueEx_SUCCESS_HKLM(int result)
+    {
+        MessageBoxExW(NULL, L"inside DeletionMarkerTests", L"Tests", 0, 0);
+
+        test_begin("RegLegacy Test DeletionMarker HKLM (SUCCESS)");
+
+        try
+        {
+            HKEY hKey;
+
+            if (RegOpenKey(HKEY_LOCAL_MACHINE, TestKeyName_HKLM_Covered, &hKey) == ERROR_SUCCESS)
+            {
+                DWORD dwType;
+                TCHAR szData[256];
+                DWORD dwDataSize = sizeof(szData);
+
+                auto response = RegQueryValueExW(hKey, TestSubItem, NULL, &dwType, (LPBYTE)szData, &dwDataSize);
+
+                if (response == ERROR_SUCCESS)
+                {
+                    trace_message(szData, console::color::gray, true);
+                    trace_messages("HKLM Deletion Marker Not Found");
+                    result = 0;
+                }
+                else if (response == ERROR_FILE_NOT_FOUND)
+                {
+                    trace_messages("HKLM Deletion Marker Found");
+                    result = ERROR_FILE_NOT_FOUND;
+                }
+                else
+                {
+                    trace_message("Failed to find read subItem.", console::color::red, true);
+                    result = GetLastError();
+                    if (result == 0)
+                        result = ERROR_FILE_NOT_FOUND;
+                    print_last_error("Failed to find read subItem");
+                }
+                RegCloseKey(hKey);
+            }
+            else
+            {
+                trace_message("Failed to find key. Most likely a bug in the testing tool.", console::color::red, true);
+                result = GetLastError();
+                if (result == 0)
+                    result = ERROR_PATH_NOT_FOUND;
+                print_last_error("Failed to find key");
+            }
+        }
+        catch (...)
+        {
+            trace_message("Unexpected error.", console::color::red, true);
+            result = GetLastError();
+            print_last_error("Failed Deletion Marker HKLM case (SUCCESS)");
+        }
+        test_end(result);
+    }
+
+    /// <summary>
+    /// Test for RegQueryValueExW
+    /// hive : HKCU
+    /// Deletion Marker Found
+    /// </summary>
+    /// <param name="result"></param>
+    inline void RegQueryValueEx_FILENOTFOUND_HKCU(int result)
+    {
+        MessageBoxExW(NULL, L"inside DeletionMarkerTests", L"Tests", 0, 0);
+
+        test_begin("RegLegacy Test DeletionMarker HKCU (FILE_NOT_FOUND)");
+
+        try
+        {
+            HKEY hKey;
+
+            if (RegOpenKeyEx(HKEY_CURRENT_USER, TestKeyName_Covered_SubKey, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+            {
+                DWORD dwType;
+                TCHAR szData[256];
+                DWORD dwDataSize = sizeof(szData);
+
+                auto response = RegQueryValueExW(hKey, TestSubItem_FILENOTFOUND, NULL, &dwType, (LPBYTE)szData, &dwDataSize);
+
+                if (response == ERROR_SUCCESS)
+                {
+                    trace_message(szData, console::color::gray, true);
+                    trace_messages("HKCU Deletion Marker Not Found");
+                    result = ERROR_CURRENT_DIRECTORY;
+                }
+                else if (response == ERROR_FILE_NOT_FOUND)
+                {
+                    trace_messages("HKCU Deletion Marker Found");
+                    result = 0;
+                }
+                else
+                {
+                    trace_message("Failed to find read subItem.", console::color::red, true);
+                    result = GetLastError();
+                    if (result == 0)
+                        result = ERROR_CURRENT_DIRECTORY;
+                    print_last_error("Failed to find read subItem");
+                }
+                RegCloseKey(hKey);
+            }
+            else
+            {
+                trace_message("Failed to find key. Most likely a bug in the testing tool.", console::color::red, true);
+                result = GetLastError();
+                if (result == 0)
+                    result = ERROR_PATH_NOT_FOUND;
+                print_last_error("Failed to find key");
+            }
+        }
+        catch (...)
+        {
+            trace_message("Unexpected error.", console::color::red, true);
+            result = GetLastError();
+            print_last_error("Failed Deletion Marker HKCU case (FILE_NOT_FOUND)");
+        }
+        test_end(result);
+    }
+
+    /// <summary>
+    /// Test for RegQueryValueExW
+    /// hive : HKLM
+    /// Deletion Marker Found
+    /// </summary>
+    /// <param name="result"></param>
+    inline void RegQueryValueEx_FILENOTFOUND_HKLM(int result)
+    {
+        MessageBoxExW(NULL, L"inside DeletionMarkerTests", L"Tests", 0, 0);
+
+        test_begin("RegLegacy Test DeletionMarker HKLM (FILE_NOT_FOUND)");
+
+        try
+        {
+            HKEY hKey;
+
+            if (RegOpenKey(HKEY_LOCAL_MACHINE, TestKeyName_HKLM_Covered, &hKey) == ERROR_SUCCESS)
+            {
+                DWORD dwType;
+                TCHAR szData[256];
+                DWORD dwDataSize = sizeof(szData);
+
+                auto response = RegQueryValueExW(hKey, TestSubItem_FILENOTFOUND, NULL, &dwType, (LPBYTE)szData, &dwDataSize);
+
+                if (response == ERROR_SUCCESS)
+                {
+                    trace_message(szData, console::color::gray, true);
+                    trace_messages("HKLM Deletion Marker Not Found");
+                    result = ERROR_CURRENT_DIRECTORY;
+                }
+                else if (response == ERROR_FILE_NOT_FOUND)
+                {
+                    trace_messages("HKLM Deletion Marker Found");
+                    result = 0;
+                }
+                else
+                {
+                    trace_message("Failed to find read subItem.", console::color::red, true);
+                    result = GetLastError();
+                    if (result == 0)
+                        result = ERROR_CURRENT_DIRECTORY;
+                    print_last_error("Failed to find read subItem");
+                }
+                RegCloseKey(hKey);
+            }
+            else
+            {
+                trace_message("Failed to find key. Most likely a bug in the testing tool.", console::color::red, true);
+                result = GetLastError();
+                if (result == 0)
+                    result = ERROR_PATH_NOT_FOUND;
+                print_last_error("Failed to find key");
+            }
+        }
+        catch (...)
+        {
+            trace_message("Unexpected error.", console::color::red, true);
+            result = GetLastError();
+            print_last_error("Failed Deletion Marker HKLM case (FILE_NOT_FOUND)");
+        }
+        test_end(result);
+    }
+}

--- a/tests/scenarios/RegLegacyTest/Helper.cpp
+++ b/tests/scenarios/RegLegacyTest/Helper.cpp
@@ -33,7 +33,7 @@ namespace Helper
     /// <param name="result"></param>
     inline void RegQueryValueEx_SUCCESS_HKCU(int result)
     {
-        test_begin("RegLegacy Test DeletionMarker HKCU (SUCCESS)");
+        test_begin("RegLegacy Test DeletionMarker - RegQueryValueEx HKCU (SUCCESS)");
 
         try
         {
@@ -94,7 +94,7 @@ namespace Helper
     /// <param name="result"></param>
     inline void RegQueryValueEx_SUCCESS_HKLM(int result)
     {
-        test_begin("RegLegacy Test DeletionMarker HKLM (SUCCESS)");
+        test_begin("RegLegacy Test DeletionMarker - RegQueryValueEx HKLM (SUCCESS)");
 
         try
         {
@@ -155,7 +155,7 @@ namespace Helper
     /// <param name="result"></param>
     inline void RegQueryValueEx_FILENOTFOUND_HKCU(int result)
     {
-        test_begin("RegLegacy Test DeletionMarker HKCU (FILE_NOT_FOUND)");
+        test_begin("RegLegacy Test DeletionMarker - RegQueryValueEx HKCU (FILE_NOT_FOUND)");
 
         try
         {
@@ -216,7 +216,7 @@ namespace Helper
     /// <param name="result"></param>
     inline void RegQueryValueEx_FILENOTFOUND_HKLM(int result)
     {
-        test_begin("RegLegacy Test DeletionMarker HKLM (FILE_NOT_FOUND)");
+        test_begin("RegLegacy Test DeletionMarker - RegQueryValueEx HKLM (FILE_NOT_FOUND)");
 
         try
         {
@@ -265,6 +265,244 @@ namespace Helper
             trace_message("Unexpected error.", console::color::red, true);
             result = GetLastError();
             print_last_error("Failed Deletion Marker HKLM case (FILE_NOT_FOUND)");
+        }
+        test_end(result);
+    }
+
+    /// <summary>
+    /// Test for RegGetValue
+    /// hive : HKCU
+    /// Deletion Marker Not Found
+    /// </summary>
+    /// <param name="result"></param>
+    inline void RegGetValue_SUCCESS_HKCU(int result)
+    {
+        test_begin("RegLegacy Test DeletionMarker - RegGetValue HKCU (SUCCESS)");
+
+        try
+        {
+            HKEY hKey;
+            if (RegOpenKeyEx(HKEY_CURRENT_USER, TestKeyName_HKCU_Covered, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+            {
+                DWORD dwType;
+                TCHAR szData[256];
+                DWORD dwDataSize = sizeof(szData);
+                auto response = RegGetValue(hKey, TestSubSubKey, TestSubItem, RRF_RT_REG_SZ, &dwType, (LPBYTE)szData, &dwDataSize);
+
+                if (response == ERROR_SUCCESS)
+                {
+                    trace_message(szData, console::color::gray, true);
+                    trace_messages("HKCU Deletion Marker Not Found");
+                    result = 0;
+                }
+                else if (response == ERROR_FILE_NOT_FOUND)
+                {
+                    trace_messages("HKCU Deletion Marker Found");
+                    result = ERROR_FILE_NOT_FOUND;
+                }
+                else
+                {
+                    trace_message("Failed to find read subItem.", console::color::red, true);
+                    result = GetLastError();
+                    if (result == 0)
+                        result = ERROR_FILE_NOT_FOUND;
+                    print_last_error("Failed to find read subItem");
+                }
+                RegCloseKey(hKey);
+            }
+            else
+            {
+                trace_message("Failed to find key. Most likely a bug in the testing tool.", console::color::red, true);
+                result = GetLastError();
+                if (result == 0)
+                    result = ERROR_PATH_NOT_FOUND;
+                print_last_error("Failed to find key");
+            }
+        }
+        catch (...)
+        {
+            trace_message("Unexpected error.", console::color::red, true);
+            result = GetLastError();
+            print_last_error("Failed Deletion Marker HKCU case (SUCCESS)");
+        }
+        test_end(result);
+    }
+
+    /// <summary>
+    /// Test for RegGetValue
+    /// hive : HKLM
+    /// Deletion Marker Found
+    /// </summary>
+    /// <param name="result"></param>
+    inline void RegGetValue_FILENOTFOUND_HKLM(int result)
+    {
+        test_begin("RegLegacy Test DeletionMarker - RegGetValue HKLM (FILENOTFOUND)");
+
+        try
+        {
+            HKEY hKey;
+            if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TestKeyName_HKLM_Covered, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+            {
+                DWORD dwType;
+                TCHAR szData[256];
+                DWORD dwDataSize = sizeof(szData);
+                auto response = RegGetValue(hKey, L"", TestSubItem_FILENOTFOUND, RRF_RT_REG_SZ, &dwType, (LPBYTE)szData, &dwDataSize);
+
+                if (response == ERROR_SUCCESS)
+                {
+                    trace_message(szData, console::color::gray, true);
+                    trace_messages("HKLM Deletion Marker Not Found");
+                    result = ERROR_CURRENT_DIRECTORY;
+                }
+                else if (response == ERROR_FILE_NOT_FOUND)
+                {
+                    trace_messages("HKLM Deletion Marker Found");
+                    result = 0;
+                }
+                else
+                {
+                    trace_message("Failed to find read subItem.", console::color::red, true);
+                    result = GetLastError();
+                    if (result == 0)
+                        result = ERROR_CURRENT_DIRECTORY;
+                    print_last_error("Failed to find read subItem");
+                }
+                RegCloseKey(hKey);
+            }
+            else
+            {
+                trace_message("Failed to find key. Most likely a bug in the testing tool.", console::color::red, true);
+                result = GetLastError();
+                if (result == 0)
+                    result = ERROR_PATH_NOT_FOUND;
+                print_last_error("Failed to find key");
+            }
+        }
+        catch (...)
+        {
+            trace_message("Unexpected error.", console::color::red, true);
+            result = GetLastError();
+            print_last_error("Failed Deletion Marker HKCU case (SUCCESS)");
+        }
+        test_end(result);
+    }
+
+    inline void RegQueryMultipleValues_SUCCESS_HKCU(int result)
+    {
+        test_begin("RegLegacy Test DeletionMarker - RegQueryMultipleValues HKCU (SUCCESS)");
+
+        try
+        {
+            HKEY hKey;
+            if (RegOpenKeyEx(HKEY_CURRENT_USER, TestKeyName_HKCU_Covered, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+            {
+
+                VALENTW value;
+                
+                DWORD num_vals = 1;
+                TCHAR szData[256];
+                DWORD dwDataSize = sizeof(szData);
+                value.ve_valuename = (LPWSTR) TestSubItem;
+                value.ve_valuelen = (sizeof(value.ve_valuename) + 1) * sizeof(WCHAR);
+                value.ve_valueptr = (DWORD_PTR)szData;
+                value.ve_type = REG_SZ;
+                
+                auto response = RegQueryMultipleValuesW(hKey, &value, num_vals, szData, &dwDataSize);
+
+                if (response == ERROR_SUCCESS)
+                {
+                    trace_message(szData, console::color::gray, true);
+                    trace_messages("HKCU Deletion Marker Not Found");
+                    result = 0;
+                }
+                else if (response == ERROR_FILE_NOT_FOUND)
+                {
+                    trace_messages("HKCU Deletion Marker Found");
+                    result = ERROR_FILE_NOT_FOUND;
+                }
+                else
+                {
+                    trace_message("Failed to find read subItem.", console::color::red, true);
+                    result = GetLastError();
+                    if (result == 0)
+                        result = ERROR_FILE_NOT_FOUND;
+                    print_last_error("Failed to find read subItem");
+                }
+                RegCloseKey(hKey);
+            }
+            else
+            {
+                trace_message("Failed to find key. Most likely a bug in the testing tool.", console::color::red, true);
+                result = GetLastError();
+                if (result == 0)
+                    result = ERROR_PATH_NOT_FOUND;
+                print_last_error("Failed to find key");
+            }
+        }
+        catch (...)
+        {
+            trace_message("Unexpected error.", console::color::red, true);
+            result = GetLastError();
+            print_last_error("Failed Deletion Marker HKCU case (SUCCESS)");
+        }
+        test_end(result);
+    }
+
+    inline void RegQueryMultipleValues_FILENOTFOUND_HKLM(int result)
+    {
+        test_begin("RegLegacy Test DeletionMarker - RegQueryMultipleValues HKLM (FILENOTFOUND)");
+
+        try
+        {
+            HKEY hKey;
+            if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TestKeyName_HKLM_Covered, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+            {
+                VALENTW value;
+                DWORD num_vals = 1;
+                TCHAR szData[256];
+                DWORD dwDataSize = sizeof(szData);
+                value.ve_valuename = (LPWSTR)TestSubItem_FILENOTFOUND;
+                value.ve_valuelen = (sizeof(value.ve_valuename) + 1) * sizeof(WCHAR);
+                value.ve_valueptr = (DWORD_PTR)szData;
+                value.ve_type = REG_SZ;
+
+                auto response = RegQueryMultipleValuesW(hKey, &value, num_vals, szData, &dwDataSize);
+
+                if (response == ERROR_SUCCESS)
+                {
+                    trace_message(szData, console::color::gray, true);
+                    trace_messages("HKLM Deletion Marker Not Found");
+                    result = ERROR_CURRENT_DIRECTORY;
+                }
+                else if (response == ERROR_FILE_NOT_FOUND)
+                {
+                    trace_messages("HKLM Deletion Marker Found");
+                    result = 0;
+                }
+                else
+                {
+                    trace_message("Failed to find read subItem.", console::color::red, true);
+                    result = GetLastError();
+                    if (result == 0)
+                        result = ERROR_CURRENT_DIRECTORY;
+                    print_last_error("Failed to find read subItem");
+                }
+                RegCloseKey(hKey);
+            }
+            else
+            {
+                trace_message("Failed to find key. Most likely a bug in the testing tool.", console::color::red, true);
+                result = GetLastError();
+                if (result == 0)
+                    result = ERROR_PATH_NOT_FOUND;
+                print_last_error("Failed to find key");
+            }
+        }
+        catch (...)
+        {
+            trace_message("Unexpected error.", console::color::red, true);
+            result = GetLastError();
+            print_last_error("Failed Deletion Marker HKLM case (SUCCESS)");
         }
         test_end(result);
     }

--- a/tests/scenarios/RegLegacyTest/Helper.cpp
+++ b/tests/scenarios/RegLegacyTest/Helper.cpp
@@ -382,7 +382,7 @@ namespace Helper
         {
             trace_message("Unexpected error.", console::color::red, true);
             result = GetLastError();
-            print_last_error("Failed Deletion Marker HKCU case (SUCCESS)");
+            print_last_error("Failed Deletion Marker HKLM case (FILENOTFOUND)");
         }
         test_end(result);
     }
@@ -515,6 +515,65 @@ namespace Helper
             trace_message("Unexpected error.", console::color::red, true);
             result = GetLastError();
             print_last_error("Failed Deletion Marker HKLM case (SUCCESS)");
+        }
+        test_end(result);
+    }
+
+    /// <summary>
+    /// Test for RegEnumValue
+    /// hive : HKLM
+    /// Deletion Marker Found
+    /// </summary>
+    /// <param name="result"></param>
+    inline void RegEnumValue_DeletionMarkerFound_HKLM(int result)
+    {
+        test_begin("RegLegacy Test DeletionMarker - RegEnumValue HKLM (Deletion Marker Found)");
+
+        try
+        {
+            HKEY hKey;
+            if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TestKeyName_HKLM_Covered, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+            {
+                DWORD dwIndex = 1;
+                WCHAR lpValueName[MAX_PATH];
+                DWORD lpcValueName = MAX_PATH;
+
+                auto response = RegEnumValue(hKey, dwIndex, lpValueName, &lpcValueName, NULL, NULL, NULL, NULL);
+
+                if (response == ERROR_SUCCESS)
+                {
+                    trace_message(lpValueName, console::color::gray, true);
+                    result = 0;
+                }
+                else if (response == ERROR_NO_MORE_ITEMS)
+                {
+                    trace_messages("Index item doesn't exists");
+                    result = 0;
+                }
+                else
+                {
+                    trace_message("Failed to find read subItem.", console::color::red, true);
+                    result = GetLastError();
+                    if (result == 0)
+                        result = ERROR_CURRENT_DIRECTORY;
+                    print_last_error("Failed to find read subItem");
+                }
+                RegCloseKey(hKey);
+            }
+            else
+            {
+                trace_message("Failed to find key. Most likely a bug in the testing tool.", console::color::red, true);
+                result = GetLastError();
+                if (result == 0)
+                    result = ERROR_PATH_NOT_FOUND;
+                print_last_error("Failed to find key");
+            }
+        }
+        catch (...)
+        {
+            trace_message("Unexpected error.", console::color::red, true);
+            result = GetLastError();
+            print_last_error("Failed Deletion Marker HKLM case (Deletion Marker Found)");
         }
         test_end(result);
     }

--- a/tests/scenarios/RegLegacyTest/Helper.cpp
+++ b/tests/scenarios/RegLegacyTest/Helper.cpp
@@ -33,8 +33,6 @@ namespace Helper
     /// <param name="result"></param>
     inline void RegQueryValueEx_SUCCESS_HKCU(int result)
     {
-        MessageBoxExW(NULL, L"inside DeletionMarkerTests", L"Tests", 0, 0);
-
         test_begin("RegLegacy Test DeletionMarker HKCU (SUCCESS)");
 
         try
@@ -96,8 +94,6 @@ namespace Helper
     /// <param name="result"></param>
     inline void RegQueryValueEx_SUCCESS_HKLM(int result)
     {
-        MessageBoxExW(NULL, L"inside DeletionMarkerTests", L"Tests", 0, 0);
-
         test_begin("RegLegacy Test DeletionMarker HKLM (SUCCESS)");
 
         try
@@ -159,8 +155,6 @@ namespace Helper
     /// <param name="result"></param>
     inline void RegQueryValueEx_FILENOTFOUND_HKCU(int result)
     {
-        MessageBoxExW(NULL, L"inside DeletionMarkerTests", L"Tests", 0, 0);
-
         test_begin("RegLegacy Test DeletionMarker HKCU (FILE_NOT_FOUND)");
 
         try
@@ -222,8 +216,6 @@ namespace Helper
     /// <param name="result"></param>
     inline void RegQueryValueEx_FILENOTFOUND_HKLM(int result)
     {
-        MessageBoxExW(NULL, L"inside DeletionMarkerTests", L"Tests", 0, 0);
-
         test_begin("RegLegacy Test DeletionMarker HKLM (FILE_NOT_FOUND)");
 
         try

--- a/tests/scenarios/RegLegacyTest/Helper.cpp
+++ b/tests/scenarios/RegLegacyTest/Helper.cpp
@@ -748,7 +748,6 @@ namespace Helper
                 DWORD dwMaxValueLen = 0;
 
                 auto response = RegQueryInfoKeyW(hkey, NULL, NULL, NULL, &dwSubKeyCount, &dwMaxSubKeyNameLen, NULL, &dwValueCount, &dwMaxValueNameLen, &dwMaxValueLen, NULL, NULL);
-                MessageBoxExW(NULL, L"Test", L"", 0, 0);
                 if (response == ERROR_SUCCESS)
                 {
                     trace_message("Query Key Success", console::color::gray, true);

--- a/tests/scenarios/RegLegacyTest/Helper.cpp
+++ b/tests/scenarios/RegLegacyTest/Helper.cpp
@@ -14,6 +14,7 @@ using namespace std::literals;
 #define TestKeyName_HKCU_Covered        L"Software\\Vendor_Covered"
 #define TestKeyName_HKCU_NotCovered     L"Software\\Vendor_NotCovered"
 
+#define TestKeyName_HKLM_SYSTEM         L"SYSTEM"
 #define TestKeyName_HKLM_Covered        L"SOFTWARE\\Vendor_Covered"        // Registry contains both regular and wow entries so this works.
 #define TestKeyName_HKLM_NotCovered     L"SOFTWARE\\Vendor_NotCovered"
 #define TestKeyName_Covered_SubKey      L"SOFTWARE\\Vendor_Covered\\SubKey"
@@ -559,6 +560,49 @@ namespace Helper
                     print_last_error("Failed to find read subItem");
                 }
                 RegCloseKey(hKey);
+            }
+            else
+            {
+                trace_message("Failed to find key. Most likely a bug in the testing tool.", console::color::red, true);
+                result = GetLastError();
+                if (result == 0)
+                    result = ERROR_PATH_NOT_FOUND;
+                print_last_error("Failed to find key");
+            }
+        }
+        catch (...)
+        {
+            trace_message("Unexpected error.", console::color::red, true);
+            result = GetLastError();
+            print_last_error("Failed Deletion Marker HKLM case (Deletion Marker Found)");
+        }
+        test_end(result);
+    }
+
+    /// <summary>
+    /// Test for RegOpenKeyEx
+    /// hive : HKLM
+    /// Deletion Marker Found
+    /// </summary>
+    /// <param name="result"></param>
+    inline void RegOpenKeyEx_FILENOTFOUND_HKLM(int result)
+    {
+        test_begin("RegLegacy Test DeletionMarker - RegOpenKeyEx HKLM (Deletion Marker Found)");
+
+        try
+        {
+            HKEY hKey;
+            auto response = RegOpenKeyEx(HKEY_LOCAL_MACHINE, TestKeyName_HKLM_SYSTEM, 0, KEY_READ, &hKey);
+            if (response == ERROR_SUCCESS)
+            {
+                trace_message("Key Opened", console::color::gray, true);
+                result = ERROR_CURRENT_DIRECTORY;
+                RegCloseKey(hKey);
+            }
+            else if (response == ERROR_FILE_NOT_FOUND)
+            {
+                trace_messages("Key doesn't exists");
+                result = 0;
             }
             else
             {

--- a/tests/scenarios/RegLegacyTest/Helper.cpp
+++ b/tests/scenarios/RegLegacyTest/Helper.cpp
@@ -387,6 +387,12 @@ namespace Helper
         test_end(result);
     }
 
+    /// <summary>
+    /// Test for RegQueryMultipleValues
+    /// hive : HKCU
+    /// Deletion Marker Not Found
+    /// </summary>
+    /// <param name="result"></param>
     inline void RegQueryMultipleValues_SUCCESS_HKCU(int result)
     {
         test_begin("RegLegacy Test DeletionMarker - RegQueryMultipleValues HKCU (SUCCESS)");
@@ -448,6 +454,12 @@ namespace Helper
         test_end(result);
     }
 
+    /// <summary>
+    /// Test for RegQueryMultipleValues
+    /// hive : HKLM
+    /// Deletion Marker Found
+    /// </summary>
+    /// <param name="result"></param>
     inline void RegQueryMultipleValues_FILENOTFOUND_HKLM(int result)
     {
         test_begin("RegLegacy Test DeletionMarker - RegQueryMultipleValues HKLM (FILENOTFOUND)");

--- a/tests/scenarios/RegLegacyTest/Helper.cpp
+++ b/tests/scenarios/RegLegacyTest/Helper.cpp
@@ -535,15 +535,15 @@ namespace Helper
             if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TestKeyName_HKLM_Covered, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
             {
                 DWORD dwIndex = 1;
-                WCHAR lpValueName[MAX_PATH];
-                DWORD lpcValueName = MAX_PATH;
+                WCHAR lpValueName[INT16_MAX];
+                DWORD lpcValueName = INT16_MAX;
 
                 auto response = RegEnumValue(hKey, dwIndex, lpValueName, &lpcValueName, NULL, NULL, NULL, NULL);
 
                 if (response == ERROR_SUCCESS)
                 {
                     trace_message(lpValueName, console::color::gray, true);
-                    result = 0;
+                    result = ERROR_CURRENT_DIRECTORY;
                 }
                 else if (response == ERROR_NO_MORE_ITEMS)
                 {

--- a/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
+++ b/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
@@ -4,7 +4,9 @@
 #include <algorithm>
 #include <ShlObj.h>
 #include <filesystem>
+#include "DeletionMarkerTest.cpp"
 
+using namespace DeletionMarkerTest;
 using namespace std::literals;
 
 namespace details
@@ -36,15 +38,7 @@ namespace details
 // The RegLegacyFixup supports only a few intercepts.
 // The tests here make routine registry calls that might have once worked but do not when running under MSIX without remediation.
 
-// THe folllowing strings must match with registry keus present in the appropriate section of the package Registry.dat file.
-#define TestKeyName_HKCU_Covered         L"Software\\Vendor_Covered"
-#define TestKeyName_HKCU_NotCovered      L"Software\\Vendor_NotCovered"
 
-#define TestKeyName_HKLM_Covered         L"SOFTWARE\\Vendor_Covered"        // Registry contains both regular and wow entries so this works.
-#define TestKeyName_HKLM_NotCovered      L"SOFTWARE\\Vendor_NotCovered"
-
-#define TestSubSubKey L"SubKey"
-#define TestSubItem  L"SubItem"
 
 
 #define FULL_RIGHTS_ACCESS_REQUEST   KEY_ALL_ACCESS
@@ -185,9 +179,11 @@ int wmain(int argc, const wchar_t** argv)
 {
     auto result = parse_args(argc, argv);
     //std::wstring aumid = details::appmodel_string(&::GetCurrentApplicationUserModelId);
-    test_initialize("RegLegacy Tests", 3);
+    test_initialize("RegLegacy Tests", 7);
 
     NotCoveredTests();
+
+    DeletionMarkerTests(result);
 
     test_begin("RegLegacy Test ModifyKeyAccess HKCU");
     try

--- a/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
+++ b/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
@@ -179,7 +179,7 @@ int wmain(int argc, const wchar_t** argv)
 {
     auto result = parse_args(argc, argv);
     //std::wstring aumid = details::appmodel_string(&::GetCurrentApplicationUserModelId);
-    test_initialize("RegLegacy Tests", 15);
+    test_initialize("RegLegacy Tests", 16);
     NotCoveredTests();
 
     DeletionMarkerTests(result);

--- a/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
+++ b/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
@@ -179,7 +179,7 @@ int wmain(int argc, const wchar_t** argv)
 {
     auto result = parse_args(argc, argv);
     //std::wstring aumid = details::appmodel_string(&::GetCurrentApplicationUserModelId);
-    test_initialize("RegLegacy Tests", 11);
+    test_initialize("RegLegacy Tests", 12);
 
     NotCoveredTests();
 

--- a/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
+++ b/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
@@ -179,7 +179,7 @@ int wmain(int argc, const wchar_t** argv)
 {
     auto result = parse_args(argc, argv);
     //std::wstring aumid = details::appmodel_string(&::GetCurrentApplicationUserModelId);
-    test_initialize("RegLegacy Tests", 13);
+    test_initialize("RegLegacy Tests", 14);
     NotCoveredTests();
 
     DeletionMarkerTests(result);

--- a/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
+++ b/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
@@ -179,7 +179,7 @@ int wmain(int argc, const wchar_t** argv)
 {
     auto result = parse_args(argc, argv);
     //std::wstring aumid = details::appmodel_string(&::GetCurrentApplicationUserModelId);
-    test_initialize("RegLegacy Tests", 7);
+    test_initialize("RegLegacy Tests", 11);
 
     NotCoveredTests();
 

--- a/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
+++ b/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
@@ -179,7 +179,7 @@ int wmain(int argc, const wchar_t** argv)
 {
     auto result = parse_args(argc, argv);
     //std::wstring aumid = details::appmodel_string(&::GetCurrentApplicationUserModelId);
-    test_initialize("RegLegacy Tests", 14);
+    test_initialize("RegLegacy Tests", 15);
     NotCoveredTests();
 
     DeletionMarkerTests(result);

--- a/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
+++ b/tests/scenarios/RegLegacyTest/RegLegacyTest.cpp
@@ -179,8 +179,7 @@ int wmain(int argc, const wchar_t** argv)
 {
     auto result = parse_args(argc, argv);
     //std::wstring aumid = details::appmodel_string(&::GetCurrentApplicationUserModelId);
-    test_initialize("RegLegacy Tests", 12);
-
+    test_initialize("RegLegacy Tests", 13);
     NotCoveredTests();
 
     DeletionMarkerTests(result);

--- a/tests/scenarios/RegLegacyTest/RegLegacyTest.vcxproj
+++ b/tests/scenarios/RegLegacyTest/RegLegacyTest.vcxproj
@@ -101,6 +101,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Ktmw32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -122,6 +123,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Ktmw32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -139,6 +141,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Ktmw32.lib;Ktmw32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -160,6 +163,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Ktmw32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/tests/scenarios/RegLegacyTest/RegLegacyTest.vcxproj.filters
+++ b/tests/scenarios/RegLegacyTest/RegLegacyTest.vcxproj.filters
@@ -21,6 +21,12 @@
     <ClCompile Include="RegLegacyTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DeletionMarkerTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Helper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Xml Include="AppXManifest.xml">
@@ -31,7 +37,10 @@
     <None Include="config.json">
       <Filter>pkg</Filter>
     </None>
-    <None Include="Registry.dat">
+    <None Include="RegistryOld.dat">
+      <Filter>pkg</Filter>
+    </None>
+    <None Include="Registry">
       <Filter>pkg</Filter>
     </None>
   </ItemGroup>

--- a/tests/scenarios/RegLegacyTest/RegLegacyTest.vcxproj.filters
+++ b/tests/scenarios/RegLegacyTest/RegLegacyTest.vcxproj.filters
@@ -21,12 +21,6 @@
     <ClCompile Include="RegLegacyTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="DeletionMarkerTest.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Helper.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Xml Include="AppXManifest.xml">
@@ -37,10 +31,7 @@
     <None Include="config.json">
       <Filter>pkg</Filter>
     </None>
-    <None Include="RegistryOld.dat">
-      <Filter>pkg</Filter>
-    </None>
-    <None Include="Registry">
+    <None Include="Registry.dat">
       <Filter>pkg</Filter>
     </None>
   </ItemGroup>

--- a/tests/scenarios/RegLegacyTest/config.json
+++ b/tests/scenarios/RegLegacyTest/config.json
@@ -24,14 +24,14 @@
                 {
                   "type": "DeletionMarker",
                   "hive": "HKLM",
-                  "key": "^TestKey",
-                  "value": "^TestValue"
+                  "key": "^SOFTWARE.*",
+                  "values": [ "DeletionMarker" ]
                 },
                 {
                   "type": "DeletionMarker",
                   "hive": "HKCU",
-                  "key": "^TestKey",
-                  "value": "^TestValue"
+                  "key": "^Software.*",
+                  "values": [ ".*" ]
                 },
                 {
                   "type": "ModifyKeyAccess",

--- a/tests/scenarios/RegLegacyTest/config.json
+++ b/tests/scenarios/RegLegacyTest/config.json
@@ -24,7 +24,7 @@
                 {
                   "type": "DeletionMarker",
                   "hive": "HKLM",
-                  "key": "^SYSTEM"
+                  "key": "^SYSTEM\\\\.*"
                 },
                 {
                   "type": "DeletionMarker",

--- a/tests/scenarios/RegLegacyTest/config.json
+++ b/tests/scenarios/RegLegacyTest/config.json
@@ -31,7 +31,7 @@
                   "type": "DeletionMarker",
                   "hive": "HKCU",
                   "key": "^Software.*",
-                  "values": [ ".*" ]
+                  "values": [ "DeletionMarker" ]
                 },
                 {
                   "type": "ModifyKeyAccess",

--- a/tests/scenarios/RegLegacyTest/config.json
+++ b/tests/scenarios/RegLegacyTest/config.json
@@ -22,6 +22,18 @@
             {
               "remediation": [
                 {
+                  "type": "DeletionMarker",
+                  "hive": "HKLM",
+                  "key": "^TestKey",
+                  "value": "^TestValue"
+                },
+                {
+                  "type": "DeletionMarker",
+                  "hive": "HKCU",
+                  "key": "^TestKey",
+                  "value": "^TestValue"
+                },
+                {
                   "type": "ModifyKeyAccess",
                   "hive": "HKCU",
                   "patterns": [

--- a/tests/scenarios/RegLegacyTest/config.json
+++ b/tests/scenarios/RegLegacyTest/config.json
@@ -24,6 +24,11 @@
                 {
                   "type": "DeletionMarker",
                   "hive": "HKLM",
+                  "key": "^SYSTEM"
+                },
+                {
+                  "type": "DeletionMarker",
+                  "hive": "HKLM",
                   "key": "^SOFTWARE.*",
                   "values": [ "DeletionMarker" ]
                 },


### PR DESCRIPTION
## Why this change is required?
This change is required to support Deletion Markers in MSIX similar to App-V as of today. 

## What changed?
1. RegLegacyFixups : 
    a. Initialize Fixups - changes to store deletion marker fixup from config.
    b. RegistryFixups - detour for APIs
2. Tests

##How this change has been tested?
Added automated tests for each detoured API.




