### PR TITLE
Address pipeline failures

### DIFF
--- a/azure-pipelines/psf-public-nuget-build.yml
+++ b/azure-pipelines/psf-public-nuget-build.yml
@@ -24,7 +24,7 @@ extends:
   parameters:
     pool:
       os: windows
-      image: windows-2019
+      image: windows-2022
       name: Azure-Pipelines-1ESPT-ExDShared
     sdl:
       baseline:
@@ -130,7 +130,7 @@ extends:
                   script: |-
                     if "%VSCMD_VER%"=="" (
                         pushd c:
-                        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
+                        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
                         popd
                     )
 
@@ -168,7 +168,7 @@ extends:
                   script: |-
                     if "%VSCMD_VER%"=="" (
                         pushd c:
-                        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
+                        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
                         popd
                     )
 

--- a/fixups/EnvVarFixup/pch.h
+++ b/fixups/EnvVarFixup/pch.h
@@ -14,5 +14,7 @@
 #include <winrt/Windows.Management.Deployment.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.Metadata.h>
+#include <winrt/Windows.System.Profile.h>
 
 #endif //PCH_H

--- a/fixups/RegLegacyFixups/InitializeFixup.cpp
+++ b/fixups/RegLegacyFixups/InitializeFixup.cpp
@@ -24,6 +24,8 @@ using namespace std::literals;
 using namespace winrt::Windows::Management::Deployment;
 using namespace winrt::Windows::ApplicationModel;
 using namespace winrt::Windows::Foundation::Collections;
+using namespace winrt::Windows::Foundation::Metadata;
+using namespace winrt::Windows::System::Profile;
 
 std::vector<Reg_Remediation_Spec>  g_regRemediationSpecs;
 
@@ -131,6 +133,14 @@ struct EntryToCreate
 Redirect_Registry CreateRegistryRedirectEntries(std::wstring_view dependency_name, const std::vector<EntryToCreate>& entries)
 {
     Redirect_Registry redirect;
+
+    if (!ApiInformation::IsPropertyPresent(L"Windows.ApplicationModel.Package", L"EffectivePath"))
+    {
+        std::wstringstream msgStream;
+        msgStream << "Redirect fixup type is not supported on " << AnalyticsInfo::VersionInfo().DeviceFamilyVersion().c_str() << " version of windows";
+        psf::TraceLogExceptions("RegLegacyFixup", msgStream.str().c_str());
+        return redirect;
+    }
 
     Log("RegLegacyFixups Create redirected registry values\n");
 

--- a/fixups/RegLegacyFixups/pch.h
+++ b/fixups/RegLegacyFixups/pch.h
@@ -14,6 +14,8 @@
 #include <winrt/Windows.Management.Deployment.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.Metadata.h>
+#include <winrt/Windows.System.Profile.h>
 
 
 #endif //PCH_H

--- a/guardian/SDL/.gdnbaselines
+++ b/guardian/SDL/.gdnbaselines
@@ -9,7 +9,7 @@
     "default": {
       "name": "default",
       "createdDate": "2024-01-18 06:34:05Z",
-      "lastUpdatedDate": "2024-01-18 06:34:05Z"
+      "lastUpdatedDate": "2024-02-07 14:50:03Z"
     }
   },
   "results": {
@@ -1493,6 +1493,106 @@
       ],
       "createdDate": "2024-01-18 06:34:05Z"
     },
+    "64b46cabd55dbfed6824f8b01c2623289b88ec33c69d4fbf3f2ebc0bf8a86a49": {
+      "signature": "64b46cabd55dbfed6824f8b01c2623289b88ec33c69d4fbf3f2ebc0bf8a86a49",
+      "alternativeSignatures": [
+        "8a2bc4c9c8a5790cdc779bfa5ab5533c83e4938e7ac194bed3cbd9ff8dd2d9d2"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "ae050ac3b5df293cd58a9507a639648ad3fb8237101dd3d1e1b5432cbcb0ced9": {
+      "signature": "ae050ac3b5df293cd58a9507a639648ad3fb8237101dd3d1e1b5432cbcb0ced9",
+      "alternativeSignatures": [
+        "f63faeaae189d5e8b9e5d1fb24a9a6de746258df71302cea6edbc0fd7418beee"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "f7568f1280cff8912c55bf6d2d4b59c185c41158b75b18db9589b4d5bca174aa": {
+      "signature": "f7568f1280cff8912c55bf6d2d4b59c185c41158b75b18db9589b4d5bca174aa",
+      "alternativeSignatures": [
+        "5c31c9d889d6cde4820ed1ea1c0dad3bd5dc726374d55955b7351683ccb149af"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "7bfb568a6861d16d6f826d32e68247e360700aeaa02b0ff4d7c5b9e6672ee479": {
+      "signature": "7bfb568a6861d16d6f826d32e68247e360700aeaa02b0ff4d7c5b9e6672ee479",
+      "alternativeSignatures": [
+        "bfb0d9bc9c2100c1e1e4b9862d256a3985a6b634c5d8216c9f7ce08d6cbfb4dd"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "6df054f20ea414a572314dd745472c5473b1f08b5dd8fd3d99aabc8974b93572": {
+      "signature": "6df054f20ea414a572314dd745472c5473b1f08b5dd8fd3d99aabc8974b93572",
+      "alternativeSignatures": [
+        "ba666afb32bef79fd79be1359cbedcc43a0b225d39526fc64663b20c6fab2554"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "cc99dd1340787171806868b883073317ca42ccc054cbd7f221f964cf6e8f9c2e": {
+      "signature": "cc99dd1340787171806868b883073317ca42ccc054cbd7f221f964cf6e8f9c2e",
+      "alternativeSignatures": [
+        "18078d0b215d819a34ffecb1dca7ef6d229063440ae9e6b5b0069b2ef08048b7"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "44abe70b54f02ac510755985ff70b4d2565428ee80bec6a97cab02bb4c37bfc3": {
+      "signature": "44abe70b54f02ac510755985ff70b4d2565428ee80bec6a97cab02bb4c37bfc3",
+      "alternativeSignatures": [
+        "64eafd78650a6c6f3aefd83d6f5620400c08ba9f4262ac936c169864c26975b3"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "19a1bf880d2b50e2b5ce3de24a96b56011a8d237b96af9719045e61c5e9737f9": {
+      "signature": "19a1bf880d2b50e2b5ce3de24a96b56011a8d237b96af9719045e61c5e9737f9",
+      "alternativeSignatures": [
+        "29c5f933e070bb4a7ba8fe73bef21a1db7b9910382ee11f4412e285cc12c8346"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "5b0158361e08b3f47e08bce7d31e407d4478dab6d6ee8fb73d7bbffbc597517f": {
+      "signature": "5b0158361e08b3f47e08bce7d31e407d4478dab6d6ee8fb73d7bbffbc597517f",
+      "alternativeSignatures": [
+        "7e80a3b087ab9172fb68e4262795790f2a5467c5941a3df449d144d7367d3100"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "3e2ea97a578d5d8f97869d3addae7b598d12f93f67b41286557d9e0f87da11c1": {
+      "signature": "3e2ea97a578d5d8f97869d3addae7b598d12f93f67b41286557d9e0f87da11c1",
+      "alternativeSignatures": [
+        "df718fcdcdb90c444571c6ea1930b8c0bf1d57b83694c26758630d1358085265"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
     "e64b7e43350c32ed7473c9b56f371091b90ab3ce3dbfef1a8b92a40bdb5f2ffe": {
       "signature": "e64b7e43350c32ed7473c9b56f371091b90ab3ce3dbfef1a8b92a40bdb5f2ffe",
       "alternativeSignatures": [
@@ -2102,6 +2202,106 @@
         "default"
       ],
       "createdDate": "2024-01-18 06:34:05Z"
+    },
+    "865e5ec8c955870b9d3970f62c289cc59766ef478891718b6c5859da59ff935a": {
+      "signature": "865e5ec8c955870b9d3970f62c289cc59766ef478891718b6c5859da59ff935a",
+      "alternativeSignatures": [
+        "ac3fe283a35a939d87a9617ccd46a17ba069a2b1b4caf4590bc2cb24a00d5fd6"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "225cd12051dea8d1a084eb236b5b498b3c00befee2de1895a54ad1f91bb7054d": {
+      "signature": "225cd12051dea8d1a084eb236b5b498b3c00befee2de1895a54ad1f91bb7054d",
+      "alternativeSignatures": [
+        "fd2d62b5a9cda192569d324078990618c67feb10b06f235cef1547bf57fe06c8"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "93c120168f3c85fac15ba6d150a348a6a39fdb863423c7e0d20d7541cee21ca0": {
+      "signature": "93c120168f3c85fac15ba6d150a348a6a39fdb863423c7e0d20d7541cee21ca0",
+      "alternativeSignatures": [
+        "2fee2e4553d8f45402c26c68fde370e892f86da6c8d554641e25ea32df0de3dd"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "a536a6c92044c1824b383ce28ea7b7d723a19b8ada541a74f9363313468ea3a5": {
+      "signature": "a536a6c92044c1824b383ce28ea7b7d723a19b8ada541a74f9363313468ea3a5",
+      "alternativeSignatures": [
+        "e2647aab345dd9f11d315fa22a340f8b072043337acd3a38735127a5a6f1963c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "444744036d85e3ce8a1681dc4da0a552dd12d21a45ab98e77e4cd2c8f903a5b9": {
+      "signature": "444744036d85e3ce8a1681dc4da0a552dd12d21a45ab98e77e4cd2c8f903a5b9",
+      "alternativeSignatures": [
+        "293b53c9e0ea8b8cf65d35119d03fec4f3a46936888e3c1d1a8e9215f06e006e"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "2d7b282c866e11d9f2ea47e75c5d0d102b777151daa542eb022c00be49ca1ae9": {
+      "signature": "2d7b282c866e11d9f2ea47e75c5d0d102b777151daa542eb022c00be49ca1ae9",
+      "alternativeSignatures": [
+        "ffeae6f662821f7058e17a6b5939245d68dbefc6f2bb9e1c2ac6196a20b6fc50"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "3fc03cc5bca69c88ff69fa7eb6c53ccc1afb8de7bd5c233e88713952f486adbc": {
+      "signature": "3fc03cc5bca69c88ff69fa7eb6c53ccc1afb8de7bd5c233e88713952f486adbc",
+      "alternativeSignatures": [
+        "de3595b4c89bbdb0d91627d85424d6543935e9dd334475df297365d09ccaa8f9"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "26534cf452efeb87fb1ba5c9830781fcce877156299a9534369b5d97a795db32": {
+      "signature": "26534cf452efeb87fb1ba5c9830781fcce877156299a9534369b5d97a795db32",
+      "alternativeSignatures": [
+        "7ab642b55d2de996efd2fc7bb253c65248d23a27d5b13bc585a58330136c7b91"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "f84fe20fde8312eaa7dbaa82b9a8e4f35c7735f19f84bab8eccf820980605f09": {
+      "signature": "f84fe20fde8312eaa7dbaa82b9a8e4f35c7735f19f84bab8eccf820980605f09",
+      "alternativeSignatures": [
+        "ec1dc9104a6e5ec2a4985329e04fbb904632184ec8100018abb433125febd416"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
+    },
+    "9672b134ac283fe0d03e805066076160aee4d76017afe2bed47057137224d3f4": {
+      "signature": "9672b134ac283fe0d03e805066076160aee4d76017afe2bed47057137224d3f4",
+      "alternativeSignatures": [
+        "3359575402843d151b2d4d8e7f3a470fe592b3ac471a648e3801141bb8168b27"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 14:50:03Z"
     },
     "4955e185fdebf84c15e2fa91974359fa8db5cb83fccc622e8cc06d98ec2b3f77": {
       "signature": "4955e185fdebf84c15e2fa91974359fa8db5cb83fccc622e8cc06d98ec2b3f77",

--- a/tests/scenarios/MiddlewareTestA/AppxManifest.xml
+++ b/tests/scenarios/MiddlewareTestA/AppxManifest.xml
@@ -20,8 +20,8 @@
     <Resource Language="en-us" />
   </Resources>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.22000.0" MaxVersionTested="10.0.22000.0" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.0.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22000.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.33130.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/tests/scenarios/MiddlewareTestA/AppxManifest.xml
+++ b/tests/scenarios/MiddlewareTestA/AppxManifest.xml
@@ -21,7 +21,7 @@
   </Resources>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22000.0" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.33130.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.27810.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/tests/scenarios/MiddlewareTestW/AppxManifest.xml
+++ b/tests/scenarios/MiddlewareTestW/AppxManifest.xml
@@ -20,8 +20,8 @@
     <Resource Language="en-us" />
   </Resources>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.14257.0" MaxVersionTested="10.0.14257.0" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.0.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22000.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.33130.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/tests/scenarios/MiddlewareTestW/AppxManifest.xml
+++ b/tests/scenarios/MiddlewareTestW/AppxManifest.xml
@@ -21,7 +21,7 @@
   </Resources>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22000.0" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.33130.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.27810.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />


### PR DESCRIPTION
- Use newer windows server 2022 instead of 2019.
- Add checks to skip framework fixups if "EffectivePath" property is not present, i.e. if we are on a pretty old version of windows
- Fix tests to depend on VCLib installed on the pool