### PR TITLE
Azure pipelines esrpsigning

### DIFF
--- a/azure-pipelines/psf-public-nuget-build.yml
+++ b/azure-pipelines/psf-public-nuget-build.yml
@@ -55,7 +55,7 @@ extends:
                   condition: and(succeeded(), eq(variables['BuildConfiguration'], 'release'))
                   publishVstsFeed: 2d59d878-551d-4bd7-a797-e4c1eca9ea33
                   packageParentPath: "$(build.artifactstagingdirectory)"
-                  packagesToPush: "$(build.artifactstagingdirectory)/**/*.nupkg;!$(build.artifactstagingdirectory)/**/packages/**/*.nupkg;!$(build.artifactstagingdirectory)/**/*.symbols.nupkg"
+                  packagesToPush: "$(build.artifactstagingdirectory)/**/*.nupkg;$(system.defaultworkingdirectory)/*.nupkg;!$(build.artifactstagingdirectory)/**/packages/**/*.nupkg;!$(build.artifactstagingdirectory)/**/*.symbols.nupkg"
                   allowPackageConflicts: true
             steps:
               - checkout: self
@@ -328,7 +328,7 @@ extends:
                 condition: and(succeeded(), eq(variables['BuildConfiguration'], 'release'))
                 inputs:
                   ConnectedServiceName: PSFNugetPackageCodeSignServiceConnection
-                  FolderPath: $(system.defaultworkingdirectory)
+                  FolderPath: ./
                   Pattern: Microsoft.PackageSupportFramework.*.nupkg
                   signConfigType: inlineSignParams
                   inlineOperation: |-

--- a/azure-pipelines/psf-public-nuget-build.yml
+++ b/azure-pipelines/psf-public-nuget-build.yml
@@ -55,7 +55,7 @@ extends:
                   condition: and(succeeded(), eq(variables['BuildConfiguration'], 'release'))
                   publishVstsFeed: 2d59d878-551d-4bd7-a797-e4c1eca9ea33
                   packageParentPath: "$(build.artifactstagingdirectory)"
-                  packagesToPush: "$(build.artifactstagingdirectory)/**/*.nupkg;$(system.defaultworkingdirectory)/**/*.nupkg;!$(build.artifactstagingdirectory)/**/packages/**/*.nupkg;!$(build.artifactstagingdirectory)/**/*.symbols.nupkg"
+                  packagesToPush: "$(build.artifactstagingdirectory)/**/*.nupkg;!$(build.artifactstagingdirectory)/**/packages/**/*.nupkg;!$(build.artifactstagingdirectory)/**/*.symbols.nupkg"
                   allowPackageConflicts: true
             steps:
               - checkout: self
@@ -351,3 +351,13 @@ extends:
                   MaxRetryAttempts: "1"
                   VerboseLogin: true
                 continueOnError: true
+
+              # copy the nuget package to ArtifactStagingDirectory for publishing
+              - task: CopyFiles@2
+                displayName: Stage created nuget
+                condition: and(succeeded(), eq(variables['BuildConfiguration'], 'release'))
+                inputs:
+                  SourceFolder: $(system.defaultworkingdirectory)
+                  Contents: "Microsoft.PackageSupportFramework*.nupkg"
+                  TargetFolder: $(Build.artifactstagingdirectory)
+                  OverWrite: true

--- a/azure-pipelines/psf-public-nuget-build.yml
+++ b/azure-pipelines/psf-public-nuget-build.yml
@@ -328,7 +328,7 @@ extends:
                 condition: and(succeeded(), eq(variables['BuildConfiguration'], 'release'))
                 inputs:
                   ConnectedServiceName: PSFNugetPackageCodeSignServiceConnection
-                  FolderPath: ./
+                  FolderPath: $(system.defaultworkingdirectory)
                   Pattern: Microsoft.PackageSupportFramework.*.nupkg
                   signConfigType: inlineSignParams
                   inlineOperation: |-

--- a/azure-pipelines/psf-public-nuget-build.yml
+++ b/azure-pipelines/psf-public-nuget-build.yml
@@ -320,7 +320,9 @@ extends:
                 inputs:
                   command: pack
                   searchPatternPack: Microsoft.PackageSupportFramework.nuspec
+                  packDestination: ./
                   versioningScheme: byBuildNumber
+                  
               - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@4
                 displayName: ESRP CodeSigning Nuget Packages
                 condition: and(succeeded(), eq(variables['BuildConfiguration'], 'release'))

--- a/azure-pipelines/psf-public-nuget-build.yml
+++ b/azure-pipelines/psf-public-nuget-build.yml
@@ -321,7 +321,6 @@ extends:
                   command: pack
                   searchPatternPack: Microsoft.PackageSupportFramework.nuspec
                   versioningScheme: byBuildNumber
-                  basePath: $(Build.BinariesDirectory)
               - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@4
                 displayName: ESRP CodeSigning Nuget Packages
                 condition: and(succeeded(), eq(variables['BuildConfiguration'], 'release'))

--- a/azure-pipelines/psf-public-nuget-build.yml
+++ b/azure-pipelines/psf-public-nuget-build.yml
@@ -55,7 +55,7 @@ extends:
                   condition: and(succeeded(), eq(variables['BuildConfiguration'], 'release'))
                   publishVstsFeed: 2d59d878-551d-4bd7-a797-e4c1eca9ea33
                   packageParentPath: "$(build.artifactstagingdirectory)"
-                  packagesToPush: "$(build.artifactstagingdirectory)/**/*.nupkg;$(system.defaultworkingdirectory)/*.nupkg;!$(build.artifactstagingdirectory)/**/packages/**/*.nupkg;!$(build.artifactstagingdirectory)/**/*.symbols.nupkg"
+                  packagesToPush: "$(build.artifactstagingdirectory)/**/*.nupkg;$(system.defaultworkingdirectory)/**/*.nupkg;!$(build.artifactstagingdirectory)/**/packages/**/*.nupkg;!$(build.artifactstagingdirectory)/**/*.symbols.nupkg"
                   allowPackageConflicts: true
             steps:
               - checkout: self


### PR DESCRIPTION
After pipeline migration, there was signing issue. The generated nupkg file was not getting signed by ESRPCodeSigning task as it was on different path. Update pipeline so that Signing task correctly signs the artifact and publishes it.