### PR TITLE
Users/snigdhalnu/psf admin changes

### DIFF
--- a/PsfLauncher/PsfLauncher.vcxproj
+++ b/PsfLauncher/PsfLauncher.vcxproj
@@ -32,6 +32,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Detours\Detours.vcxproj">
+      <Project>{79db420c-0c71-4948-a93c-821761a8105b}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\PsfRuntime\PsfRuntime.vcxproj">
       <Project>{87cce0ac-a7fb-4a31-89d3-c0acdb315ee0}</Project>
     </ProjectReference>

--- a/PsfLauncher/main.cpp
+++ b/PsfLauncher/main.cpp
@@ -39,6 +39,7 @@ LARGE_INTEGER psfLoad_startCounter;
 void LogApplicationAndProcessesCollection();
 int launcher_main(PCWSTR args, int cmdShow) noexcept;
 void GetAndLaunchMonitor(const psf::json_object& monitor, std::filesystem::path packageRoot, int cmdShow, LPCWSTR dirStr);
+void LaunchInBackgroundAsAdmin(const wchar_t executable[], const wchar_t arguments[], bool wait, int cmdShow, LPCWSTR dirStr); 
 void LaunchMonitorInBackground(std::filesystem::path packageRoot, const wchar_t executable[], const wchar_t arguments[], bool wait, bool asAdmin, int cmdShow, LPCWSTR dirStr);
 bool IsCurrentOSRS2OrGreater();
 std::wstring ReplaceVariablesInString(std::wstring inputString, bool ReplaceEnvironmentVars, bool ReplacePseudoVars);
@@ -166,7 +167,11 @@ int launcher_main(PCWSTR args, int cmdShow) noexcept try
         }
         if (hr != ERROR_SUCCESS)
         {
-            Log("Error return from launching process 0x%x.", GetLastError());
+            Log("Error return from launching process second try, try again 0x%x.", GetLastError());
+        }
+        if (hr != ERROR_SUCCESS)
+        {
+            LaunchInBackgroundAsAdmin(exePath.c_str(), args, true, cmdShow, currentDirectory.c_str());
         }
     }
     else
@@ -201,6 +206,9 @@ catch (...)
     return win32_from_caught_exception();
 }
 
+
+
+
 void GetAndLaunchMonitor(const psf::json_object& monitor, std::filesystem::path packageRoot, int cmdShow, LPCWSTR dirStr)
 {
     std::wstringstream traceDataStream;
@@ -229,6 +237,156 @@ void GetAndLaunchMonitor(const psf::json_object& monitor, std::filesystem::path 
     Log("\tCreating the monitor: %ls", monitorExecutable->as_string().wide());
     LaunchMonitorInBackground(packageRoot, monitorExecutable->as_string().wide(), monitorArguments->as_string().wide(), wait, asAdmin, cmdShow, dirStr);
 }
+
+void LaunchInBackgroundAsAdmin(const wchar_t executable[], const wchar_t arguments[], bool wait, int cmdShow, LPCWSTR dirStr)
+{
+    std::wstring cmd = L"\"";
+    cmd.append(executable);
+    cmd.append(L"\"");
+
+
+    // This happens when the program is requested for elevation.  For now just launch this way.  We don't get to inject,
+    // but it is better than nothing.
+    SHELLEXECUTEINFOW shExInfo =
+    {
+        sizeof(shExInfo) // bSize
+        , wait ? (ULONG)SEE_MASK_NOCLOSEPROCESS : (ULONG)(SEE_MASK_NOCLOSEPROCESS | SEE_MASK_WAITFORINPUTIDLE) // fmask
+        , 0           // hwnd
+        , L"runas"    // lpVerb
+        , cmd.c_str() // lpFile
+        , arguments   // lpParameters
+        , dirStr     // lpDirectory
+        , cmdShow           // nShow
+        , 0           // hInstApp
+    };
+    Log("PsfLaunch: Unable to launch with injection (possibly due to elevation).  Launch using shell launch without injection.");
+    THROW_LAST_ERROR_IF_MSG(!ShellExecuteEx(&shExInfo), "Error starting monitor using ShellExecuteEx");
+    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE), shExInfo.hProcess == INVALID_HANDLE_VALUE);
+
+    // possibly inject the runtime now?
+#if INECTIONFROMHEREREADY
+    try
+    {
+        BOOL b;
+        BOOL res = IsProcessInJob(shExInfo.hProcess, nullptr, &b);
+        if (res != 0)
+        {
+            if (b == true)
+            {
+                Log(L"\tPsfLaunch: New process is in a job, allow injection.");
+                // Fix for issue #167: allow subprocess to be a different bitness than this process.
+                USHORT bitness = ProcessBitness(shExInfo.hProcess);
+                DWORD procId = GetProcessId(shExInfo.hProcess);
+                std::filesystem::path packageRoot = PSFQueryPackageRootPath();
+#if _DEBUG
+                Log(L"\tPsfLaunch: Injection for PID=%d Bitness=%d", procId, bitness);
+#endif  
+                std::wstring wtargetDllName = FixDllBitness(std::wstring(psf::runtime_dll_name), bitness);
+#if _DEBUG
+                Log(L"\tPsfLaunch: Use runtime %ls", wtargetDllName.c_str());
+#endif
+                static const auto pathToPsfRuntime = (packageRoot / wtargetDllName.c_str()).string();
+                const char* targetDllPath = NULL;
+#if _DEBUG
+                Log("\tPsfLaunch: Inject %s into PID=%d", pathToPsfRuntime.c_str(), procId);
+#endif
+
+                if (std::filesystem::exists(pathToPsfRuntime))
+                {
+                    targetDllPath = pathToPsfRuntime.c_str();
+                }
+                else
+                {
+                    // Possibly the dll is in the folder with the exe and not at the package root.
+                    Log(L"\tPsfLaunch: %ls not found at package root, try target folder.", wtargetDllName.c_str());
+
+                    std::filesystem::path altPathToExeRuntime = executable;
+                    static const auto altPathToPsfRuntime = (altPathToExeRuntime.parent_path() / pathToPsfRuntime.c_str()).string();
+#if _DEBUG
+                    Log(L"\tPsfLaunch: alt target filename is now %ls", altPathToPsfRuntime.c_str());
+#endif
+                    if (std::filesystem::exists(altPathToPsfRuntime))
+                    {
+                        targetDllPath = altPathToPsfRuntime.c_str();
+                    }
+                    else
+                    {
+#if _DEBUG
+                        Log(L"\tPsfLaunch: Not present there either, try elsewhere in package.");
+#endif
+                        // If not in those two locations, must check everywhere in package.
+                        // The child process might also be in another package folder, so look elsewhere in the package.
+                        for (auto& dentry : std::filesystem::recursive_directory_iterator(packageRoot))
+                        {
+                            try
+                            {
+                                if (dentry.path().filename().compare(wtargetDllName) == 0)
+                                {
+                                    static const auto altDirPathToPsfRuntime = narrow(dentry.path().c_str());
+#if _DEBUG
+                                    Log(L"\tPsfLaunch: Found match as %ls", dentry.path().c_str());
+#endif
+                                    targetDllPath = altDirPathToPsfRuntime.c_str();
+                                    break;
+                                }
+                            }
+                            catch (...)
+                            {
+                                Log(L"\tPsfLaunch: Non-fatal error enumerating directories while looking for PsfRuntime.");
+                            }
+                        }
+
+                    }
+                }
+
+                if (targetDllPath != NULL)
+                {
+                    Log("\tPsfLaunch: Attempt injection into %d using %s", procId, targetDllPath);
+                    if (!::DetourUpdateProcessWithDll(processInformation->hProcess, &targetDllPath, 1))
+                    {
+                        Log("\tPsfLaunch: %s unable to inject, err=0x%x.", targetDllPath, ::GetLastError());
+                        if (!::DetourProcessViaHelperDllsW(processInformation->dwProcessId, 1, &targetDllPath, CreateProcessWithPsfRunDll))
+                        {
+                            Log("\tPsfLaunch: %s unable to inject with RunDll either (Skipping), err=0x%x.", targetDllPath, ::GetLastError());
+                        }
+                    }
+                    else
+                    {
+                        Log(L"\tPsfLaunch: Injected %ls into PID=%d\n", wtargetDllName.c_str(), processInformation->dwProcessId);
+                    }
+                }
+                else
+                {
+                    Log(L"\tPsfLaunch: %ls not found, skipping.", wtargetDllName.c_str());
+                }
+            }
+        }
+    }
+    catch (...)
+    {
+#if _DEBUG
+        Log(L"\tPsfLaunch: Exception while trying to determine job status of new process. Do not inject.");
+#endif
+
+    }
+#endif
+
+
+    if (wait)
+    {
+        WaitForSingleObject(shExInfo.hProcess, INFINITE);
+        CloseHandle(shExInfo.hProcess);
+    }
+    else
+    {
+        WaitForInputIdle(shExInfo.hProcess, 1000);
+        // Due to elevation, the process starts, relaunches, and the main process ends in under 1ms.
+        // So we'll just toss in an ugly sleep here for now.
+        Sleep(5000);
+    }
+
+}
+
 
 void LaunchMonitorInBackground(std::filesystem::path packageRoot, const wchar_t executable[], const wchar_t arguments[], bool wait, bool asAdmin, int cmdShow, LPCWSTR dirStr)
 {

--- a/PsfLauncher/main.cpp
+++ b/PsfLauncher/main.cpp
@@ -293,18 +293,12 @@ void LaunchInBackgroundAsAdmin(const wchar_t executable[], const wchar_t argumen
                 USHORT bitness = ProcessBitness(shExInfo.hProcess);
                 DWORD procId = GetProcessId(shExInfo.hProcess);
                 std::filesystem::path packageRoot = PSFQueryPackageRootPath();
-#if _DEBUG
                 Log("\tPsfLaunch: Injection for PID=%d Bitness=%d", procId, bitness);
-#endif  
                 std::wstring wtargetDllName = FixupDllBitness(std::wstring(psf::runtime_dll_name), bitness);
-#if _DEBUG
                 Log("\tPsfLaunch: Use runtime %ls", wtargetDllName.c_str());
-#endif
                 static const auto pathToPsfRuntime = (packageRoot / wtargetDllName.c_str()).string();
                 const char* targetDllPath = nullptr;
-#if _DEBUG
                 Log("\tPsfLaunch: Inject %s into PID=%d", pathToPsfRuntime.c_str(), procId);
-#endif
 
                 if (std::filesystem::exists(pathToPsfRuntime))
                 {
@@ -317,18 +311,14 @@ void LaunchInBackgroundAsAdmin(const wchar_t executable[], const wchar_t argumen
 
                     std::filesystem::path altPathToExeRuntime = executable;
                     static const auto altPathToPsfRuntime = (altPathToExeRuntime.parent_path() / pathToPsfRuntime.c_str()).string();
-#if _DEBUG
                     Log("\tPsfLaunch: alt target filename is now %ls", altPathToPsfRuntime.c_str());
-#endif
                     if (std::filesystem::exists(altPathToPsfRuntime))
                     {
                         targetDllPath = altPathToPsfRuntime.c_str();
                     }
                     else
                     {
-#if _DEBUG
                         Log("\tPsfLaunch: Not present there either, try elsewhere in package.");
-#endif
                         // If not in those two locations, must check everywhere in package.
                         // The child process might also be in another package folder, so look elsewhere in the package.
                         for (auto& dentry : std::filesystem::recursive_directory_iterator(packageRoot))
@@ -338,9 +328,7 @@ void LaunchInBackgroundAsAdmin(const wchar_t executable[], const wchar_t argumen
                                 if (dentry.path().filename().compare(wtargetDllName) == 0)
                                 {
                                     static const auto altDirPathToPsfRuntime = narrow(dentry.path().c_str());
-#if _DEBUG
                                     Log("\tPsfLaunch: Found match as %ls", dentry.path().c_str());
-#endif
                                     targetDllPath = altDirPathToPsfRuntime.c_str();
                                     break;
                                 }
@@ -378,10 +366,7 @@ void LaunchInBackgroundAsAdmin(const wchar_t executable[], const wchar_t argumen
     }
     catch (...)
     {
-#if _DEBUG
         Log("\tPsfLaunch: Exception while trying to determine job status of new process. Do not inject.");
-#endif
-
     }
 
 

--- a/PsfLauncher/main.cpp
+++ b/PsfLauncher/main.cpp
@@ -177,9 +177,6 @@ int launcher_main(PCWSTR args, int cmdShow) noexcept try
         if (hr != ERROR_SUCCESS)
         {
             Log("Error return from launching process second try, try again 0x%x.", GetLastError());
-        }
-        if (hr != ERROR_SUCCESS)
-        {
             LaunchInBackgroundAsAdmin(exePath.c_str(), args, true, cmdShow, currentDirectory.c_str());
         }
     }

--- a/PsfLauncher/main.cpp
+++ b/PsfLauncher/main.cpp
@@ -266,8 +266,15 @@ void LaunchInBackgroundAsAdmin(const wchar_t executable[], const wchar_t argumen
         , 0           // hInstApp
     };
     Log("PsfLaunch: Unable to launch with injection (possibly due to elevation).  Launch using shell launch without injection.");
-    THROW_LAST_ERROR_IF_MSG(!ShellExecuteEx(&shExInfo), "Error starting monitor using ShellExecuteEx");
-    THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE), shExInfo.hProcess == INVALID_HANDLE_VALUE);
+    try
+    {
+        THROW_LAST_ERROR_IF_MSG(!ShellExecuteEx(&shExInfo), "Error starting monitor using ShellExecuteEx");
+        THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE), shExInfo.hProcess == INVALID_HANDLE_VALUE);
+    }
+    catch(...)
+    {
+        return;
+    }
 
     // possibly inject the runtime now?
     try

--- a/PsfRuntime/CreateProcessHook.cpp
+++ b/PsfRuntime/CreateProcessHook.cpp
@@ -21,6 +21,7 @@
 #include <windows.h>
 #include <detours.h>
 #include <psf_constants.h>
+#include <psf_runtime.h>
 #include <psf_framework.h>
 
 #include "Config.h"
@@ -31,6 +32,7 @@ using namespace std::literals;
 
 void Log(const char* fmt, ...);
 
+    
 // Function to determine if this process should get 32 or 64bit dll injections
 // Returns 32 or 64 (or 0 for error)
 typedef BOOL(WINAPI* LPFN_ISWOW64PROCESS2) (HANDLE, PUSHORT, PUSHORT);

--- a/include/psf_runtime.h
+++ b/include/psf_runtime.h
@@ -59,4 +59,19 @@ inline const psf::json_value* PSFQueryCurrentDllConfig()
 
 PSFAPI void __stdcall PSFReportError(const wchar_t* error) noexcept;
 
+
+
 }
+
+PSFAPI extern USHORT ProcessBitness(HANDLE hProcess);
+PSFAPI extern BOOL WINAPI CreateProcessWithPsfRunDll(
+    [[maybe_unused]] _In_opt_ LPCWSTR applicationName,
+    _Inout_opt_ LPWSTR commandLine,
+    _In_opt_ LPSECURITY_ATTRIBUTES processAttributes,
+    _In_opt_ LPSECURITY_ATTRIBUTES threadAttributes,
+    _In_ BOOL inheritHandles,
+    _In_ DWORD creationFlags,
+    _In_opt_ LPVOID environment,
+    _In_opt_ LPCWSTR currentDirectory,
+    _In_ LPSTARTUPINFOW startupInfo,
+    _Out_ LPPROCESS_INFORMATION processInformation) noexcept;


### PR DESCRIPTION
#Why were the changes made?
PSF does not work when app requires UAC prompt.
To support the applications requiring admin privileges to launch

#What changed?
Added a functionality to launch application with UAC prompt if launching them normally fails.
To use API ShellExecuteEx rather than CreateProcessW to launch application in admin mode.

#How were the changes tested?
Performed test with msix requiring admin privileges.